### PR TITLE
Feature video url builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,18 @@ For creating the poster URL by the movie item.
 val url = TmdbImageUrlBuilder.buildPoster(item = movie, width = 200)
 ```
 
+### Build video URL
+
+You can build a video URL by the key value into `TmdbVideo`. TMDb API currently support videos from YouTube and Vimeo
+
+```kotlin
+val youtubeTmdbVideo = TmdbVideo(id = "123", key = "qwerasdf", site = TmdbVideoSite.YOUTUBE)
+val url = TmdbImageUrlBuilder.build(youtubeTmdbVideo) // It will return `https://www.youtube.com/watch?v=qwerasdf`
+
+val vimeoTmdbVideo = TmdbVideo(id = "123", key = "qwerasdf", site = TmdbVideoSite.VIMEO)
+val url = TmdbImageUrlBuilder.build(vimeoTmdbVideo) // It will return `https://vimeo.com/qwerasdf`
+```
+
 <br>
 
 <hr>

--- a/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/model/TmdbModel.kt
+++ b/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/model/TmdbModel.kt
@@ -126,6 +126,15 @@ enum class TmdbVideoType(val value: String) {
     BEHIND_THE_SCENES("Behind the Scenes");
 }
 
+@Serializable
+enum class TmdbVideoSite(val value: String) {
+    @SerialName("YouTube")
+    YOUTUBE("YouTube"),
+
+    @SerialName("Vimeo")
+    VIMEO("Vimeo"),
+}
+
 /**
  *
  */
@@ -134,7 +143,8 @@ data class TmdbVideo(
     @SerialName("id") val id: String,
     @SerialName("iso_639_1") val iso639: String? = null,
     @SerialName("iso_3166_1") val iso3166: String? = null,
-    @SerialName("key") val key: String? = null,
+    @SerialName("key") val key: String,
+    @SerialName("site") val site: TmdbVideoSite,
     @SerialName("name") val name: String? = null,
     @SerialName("size") val size: Int? = null, // 360, 480, 720, 1080
     @SerialName("type") val type: TmdbVideoType? = null,

--- a/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/video/TmdbVideoUrlBuilder.kt
+++ b/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/video/TmdbVideoUrlBuilder.kt
@@ -1,0 +1,15 @@
+package app.moviebase.tmdb.video
+
+import app.moviebase.tmdb.model.TmdbVideo
+import app.moviebase.tmdb.model.TmdbVideoSite
+
+object TmdbVideoUrlBuilder {
+
+    /**
+     * Build the video URL depending on the site the video is from
+     */
+    fun build(tmdbVideo: TmdbVideo): String = when (tmdbVideo.site) {
+        TmdbVideoSite.YOUTUBE -> "https://www.youtube.com/watch?v=${tmdbVideo.key}"
+        TmdbVideoSite.VIMEO -> "https://vimeo.com/${tmdbVideo.key}"
+    }
+}

--- a/tmdb-api/src/jvmTest/kotlin/app/moviebase/tmdb/image/TmdbImageUrlBuilderTest.kt
+++ b/tmdb-api/src/jvmTest/kotlin/app/moviebase/tmdb/image/TmdbImageUrlBuilderTest.kt
@@ -1,6 +1,7 @@
 package app.moviebase.tmdb.image
 
 import app.moviebase.tmdb.model.TmdbVideo
+import app.moviebase.tmdb.model.TmdbVideoSite
 import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Test
 
@@ -38,7 +39,7 @@ class TmdbImageUrlBuilderTest {
 
     @Test
     fun testBuildYouTubeUrlByTmdbVideo() {
-        val tmdbVideo = TmdbVideo(id = "45", key = "sdfjkds")
+        val tmdbVideo = TmdbVideo(id = "45", key = "sdfjkds", site = TmdbVideoSite.YOUTUBE)
         val imageUrl = TmdbImageUrlBuilder.buildYoutube(tmdbVideo, 320)
 
         assertThat(imageUrl).isEqualTo("https://img.youtube.com/vi/sdfjkds/mqdefault.jpg")

--- a/tmdb-api/src/jvmTest/kotlin/app/moviebase/tmdb/video/TmdbVideoUrlBuilderTest.kt
+++ b/tmdb-api/src/jvmTest/kotlin/app/moviebase/tmdb/video/TmdbVideoUrlBuilderTest.kt
@@ -1,0 +1,27 @@
+package app.moviebase.tmdb.video
+
+import app.moviebase.tmdb.model.TmdbVideo
+import app.moviebase.tmdb.model.TmdbVideoSite
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+internal class TmdbVideoUrlBuilderTest {
+
+    @Test
+    fun `Should return a proper YouTube url`() {
+        val tmdbVideo = TmdbVideo(id = "123", key = "qwerasdf", site = TmdbVideoSite.YOUTUBE)
+
+        val videoUrl = TmdbVideoUrlBuilder.build(tmdbVideo)
+
+        assertThat(videoUrl).isEqualTo("https://www.youtube.com/watch?v=qwerasdf")
+    }
+
+    @Test
+    fun `Should return a proper Vimeo url`() {
+        val tmdbVideo = TmdbVideo(id = "123", key = "qwerasdf", site = TmdbVideoSite.VIMEO)
+
+        val videoUrl = TmdbVideoUrlBuilder.build(tmdbVideo)
+
+        assertThat(videoUrl).isEqualTo("https://vimeo.com/qwerasdf")
+    }
+}


### PR DESCRIPTION
Create the class `TmdbVideoUrlBuilder` to provide a method to generate Video URLs from the `TmdbVideo` entities received from the API.

The current allowed Videos are from YouTube and Vimeo (From March 23, 2019, as was shown [here](https://developers.themoviedb.org/3/movies/get-movie-videos)

The `key` value returned on the API represents the platform video ID and the `site` value the platform itself. A new `enum` has been created to model the `site` and depending on it we use a different base URL as is detailed [here](https://www.themoviedb.org/talk/5955219ec3a3680d73048c7e#5ca6d0ff0e0a261f3b332f8d)