### PR TITLE
Allow clients to customize HttpClient

### DIFF
--- a/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/Tmdb3.kt
+++ b/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/Tmdb3.kt
@@ -2,18 +2,27 @@ package app.moviebase.tmdb
 
 import app.moviebase.tmdb.api.*
 import app.moviebase.tmdb.remote.TmdbHttpClientFactory
-import app.moviebase.tmdb.remote.TmdbSessionProvider
 import app.moviebase.tmdb.remote.TmdbLogLevel
+import app.moviebase.tmdb.remote.TmdbSessionProvider
 import io.ktor.client.*
 
 class Tmdb3(
     tmdbApiKey: String,
     logLevel: TmdbLogLevel = TmdbLogLevel.NONE,
-    tmdbSessionProvider: TmdbSessionProvider? = null
+    tmdbSessionProvider: TmdbSessionProvider? = null,
+    httpClientConfigBlock: (HttpClientConfig<*>.() -> Unit)? = null,
 ) {
-
-    private val client: HttpClient = TmdbHttpClientFactory.create(tmdbApiKey, logLevel)
-    private val clientWithSession: HttpClient = TmdbHttpClientFactory.createWithSession(tmdbApiKey, logLevel, tmdbSessionProvider)
+    private val client: HttpClient = TmdbHttpClientFactory.create(
+        tmdbApiKey = tmdbApiKey,
+        logLevel = logLevel,
+        httpClientConfigBlock = httpClientConfigBlock,
+    )
+    private val clientWithSession: HttpClient = TmdbHttpClientFactory.createWithSession(
+        tmdbApiKey = tmdbApiKey,
+        logLevel = logLevel,
+        tmdbSessionProvider = tmdbSessionProvider,
+        httpClientConfigBlock = httpClientConfigBlock,
+    )
 
     val account = TmdbAccountApi(clientWithSession)
     val authentication = TmdbAuthenticationApi(client)

--- a/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/Tmdb4.kt
+++ b/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/Tmdb4.kt
@@ -5,29 +5,36 @@ import app.moviebase.tmdb.api.Tmdb4AuthenticationApi
 import app.moviebase.tmdb.api.Tmdb4ListApi
 import app.moviebase.tmdb.remote.TmdbLogLevel
 import app.moviebase.tmdb.remote.buildHttpClient
+import app.moviebase.tmdb.remote.interceptRequest
+import io.ktor.client.*
 import io.ktor.client.request.*
 
 class Tmdb4(
     tmdbApiKey: String,
     authenticationToken: String? = null,
-    logLevel: TmdbLogLevel = TmdbLogLevel.NONE
+    logLevel: TmdbLogLevel = TmdbLogLevel.NONE,
+    httpClientConfigBlock: (HttpClientConfig<*>.() -> Unit)? = null,
 ) {
 
     var accessToken: String? = null
     var requestToken: String? = null
 
-    private val client = buildHttpClient(logLevel) {
-        it.parameter(TmdbUrlParameter.API_KEY, tmdbApiKey)
-        accessToken?.let { token ->
-            it.header("Authorization", "Bearer $token")
+    private val client = buildHttpClient(logLevel, httpClientConfigBlock).apply {
+        interceptRequest {
+            it.parameter(TmdbUrlParameter.API_KEY, tmdbApiKey)
+            accessToken?.let { token ->
+                it.header("Authorization", "Bearer $token")
+            }
         }
     }
 
-    private val authClient = buildHttpClient(logLevel) {
-        // TODO: Install Auth client https://ktor.io/docs/auth.html
-        it.parameter(TmdbUrlParameter.API_KEY, tmdbApiKey)
-        requireNotNull(authenticationToken) { "authentication token not set for request auth endpoints" }
-        it.header("Authorization", "Bearer $authenticationToken")
+    private val authClient = buildHttpClient(logLevel, httpClientConfigBlock).apply {
+        interceptRequest {
+            // TODO: Install Auth client https://ktor.io/docs/auth.html
+            it.parameter(TmdbUrlParameter.API_KEY, tmdbApiKey)
+            requireNotNull(authenticationToken) { "authentication token not set for request auth endpoints" }
+            it.header("Authorization", "Bearer $authenticationToken")
+        }
     }
 
     val account = Tmdb4AccountApi(client)

--- a/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/remote/RemoteModel.kt
+++ b/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/remote/RemoteModel.kt
@@ -12,7 +12,10 @@ import io.ktor.serialization.kotlinx.json.*
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
 
-internal fun buildHttpClient(logLevel: TmdbLogLevel = TmdbLogLevel.NONE, interceptor: RequestInterceptor): HttpClient {
+internal fun buildHttpClient(
+    logLevel: TmdbLogLevel = TmdbLogLevel.NONE,
+    httpClientConfigBlock: (HttpClientConfig<*>.() -> Unit)? = null,
+): HttpClient {
     val json = buildJson()
 
     val httpClient = HttpClient {
@@ -35,8 +38,9 @@ internal fun buildHttpClient(logLevel: TmdbLogLevel = TmdbLogLevel.NONE, interce
             socketTimeoutMillis = 60_000
         }
 
+        // Allow the provided block to customize the config
+        httpClientConfigBlock?.invoke(this)
     }
-    httpClient.interceptRequest(interceptor = interceptor)
     return httpClient
 }
 

--- a/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/remote/TmdbHttpClientFactory.kt
+++ b/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/remote/TmdbHttpClientFactory.kt
@@ -1,20 +1,39 @@
 package app.moviebase.tmdb.remote
 
 import app.moviebase.tmdb.TmdbUrlParameter
+import io.ktor.client.*
 import io.ktor.client.request.*
 
 internal object TmdbHttpClientFactory {
 
-    fun create(tmdbApiKey: String, logLevel: TmdbLogLevel) = buildHttpClient(logLevel) {
-        it.parameter(TmdbUrlParameter.API_KEY, tmdbApiKey)
+    fun create(
+        tmdbApiKey: String,
+        logLevel: TmdbLogLevel,
+        httpClientConfigBlock: (HttpClientConfig<*>.() -> Unit)? = null,
+    ) = buildHttpClient(
+        logLevel = logLevel,
+        httpClientConfigBlock = httpClientConfigBlock,
+    ).apply {
+        interceptRequest {
+            it.parameter(TmdbUrlParameter.API_KEY, tmdbApiKey)
+        }
     }
 
-    fun createWithSession(tmdbApiKey: String, logLevel: TmdbLogLevel, tmdbSessionProvider: TmdbSessionProvider?) =
-        buildHttpClient(logLevel) {
+    fun createWithSession(
+        tmdbApiKey: String,
+        logLevel: TmdbLogLevel,
+        tmdbSessionProvider: TmdbSessionProvider?,
+        httpClientConfigBlock: (HttpClientConfig<*>.() -> Unit)? = null,
+    ) = buildHttpClient(
+        logLevel = logLevel,
+        httpClientConfigBlock = httpClientConfigBlock
+    ).apply {
+        interceptRequest {
             val sessionId = tmdbSessionProvider?.getId()
             requireNotNull(sessionId) { "session id is not set in the Tmdb3 instance" }
 
             it.parameter(TmdbUrlParameter.API_KEY, tmdbApiKey)
             it.parameter(TmdbUrlParameter.SESSION_ID, sessionId)
         }
+    }
 }


### PR DESCRIPTION
This PR adds a `(HttpClientConfig<*>.() -> Unit)` constructor parameter to Tmdb3 and Tmdb4, allowing clients to customize the Ktor client as they wish.

My primary use case is to enable persistent Http caching (https://ktor.io/docs/client-caching.html#persistent_cache), but there are lots of other use cases too.