### PR TITLE
Fix API dependencies

### DIFF
--- a/tmdb-api/build.gradle.kts
+++ b/tmdb-api/build.gradle.kts
@@ -28,10 +28,10 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(libs.kotlinx.coroutines.core)
-                implementation(libs.kotlinx.serialization)
-                implementation(libs.kotlinx.datetime)
-                implementation(libs.ktor.core)
+                api(libs.kotlinx.coroutines.core)
+                api(libs.kotlinx.serialization)
+                api(libs.kotlinx.datetime)
+                api(libs.ktor.core)
                 implementation(libs.ktor.json)
                 implementation(libs.ktor.logging)
                 implementation(libs.ktor.serialization.json)


### PR DESCRIPTION
datetime, ktor and coroutines and serialization are all exposed via the public API, therefore need to be exposed as API dependencies.