### PR TITLE
Fix types and add new fields for Discover

### DIFF
--- a/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/discover/DiscoverCategory.kt
+++ b/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/discover/DiscoverCategory.kt
@@ -1,5 +1,6 @@
 package app.moviebase.tmdb.discover
 
+import app.moviebase.tmdb.model.TmdbDiscoverFilter
 import app.moviebase.tmdb.model.TmdbMediaType
 import app.moviebase.tmdb.model.TmdbNetworkId
 import app.moviebase.tmdb.model.TmdbWatchProviderId
@@ -21,30 +22,30 @@ sealed class DiscoverCategory {
             val APPLE_TV = Network(TmdbNetworkId.APPLE_TV)
         }
     }
-    data class OnStreaming(val mediaType: TmdbMediaType, val watchRegion: String, val watchProviders: List<Int>) : DiscoverCategory() {
+    data class OnStreaming(val mediaType: TmdbMediaType, val watchRegion: String, val watchProviders: TmdbDiscoverFilter<Int>) : DiscoverCategory() {
         companion object {
             fun Netflix(mediaType: TmdbMediaType, watchRegion: String) = OnStreaming(
                 mediaType,
                 watchRegion,
-                listOf(TmdbWatchProviderId.NETFLIX)
+                TmdbDiscoverFilter(items = listOf(TmdbWatchProviderId.NETFLIX))
             )
 
             fun AmazonPrimeVideo(mediaType: TmdbMediaType, watchRegion: String) = OnStreaming(
                 mediaType,
                 watchRegion,
-                listOf(TmdbWatchProviderId.AMAZON_PRIME_VIDEO)
+                TmdbDiscoverFilter(items = listOf(TmdbWatchProviderId.AMAZON_PRIME_VIDEO))
             )
 
             fun AppleTv(mediaType: TmdbMediaType, watchRegion: String) = OnStreaming(
                 mediaType,
                 watchRegion,
-                listOf(TmdbWatchProviderId.APPLE_TV_PLUS)
+                TmdbDiscoverFilter(items = listOf(TmdbWatchProviderId.APPLE_TV_PLUS))
             )
 
             fun DisneyPlus(mediaType: TmdbMediaType, watchRegion: String) = OnStreaming(
                 mediaType,
                 watchRegion,
-                listOf(TmdbWatchProviderId.DISNEY_PLUS)
+                TmdbDiscoverFilter(items = listOf(TmdbWatchProviderId.DISNEY_PLUS))
             )
         }
     }

--- a/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/discover/DiscoverFactory.kt
+++ b/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/discover/DiscoverFactory.kt
@@ -1,15 +1,16 @@
 package app.moviebase.tmdb.discover
 
+import app.moviebase.tmdb.core.currentLocalDate
+import app.moviebase.tmdb.core.minusWeeks
+import app.moviebase.tmdb.core.plusDays
+import app.moviebase.tmdb.core.plusWeeks
 import app.moviebase.tmdb.model.TmdbDiscover
+import app.moviebase.tmdb.model.TmdbDiscoverFilter
 import app.moviebase.tmdb.model.TmdbDiscoverMovieSortBy
 import app.moviebase.tmdb.model.TmdbDiscoverShowSortBy
 import app.moviebase.tmdb.model.TmdbDiscoverTimeRange
 import app.moviebase.tmdb.model.TmdbMediaType
 import app.moviebase.tmdb.model.TmdbReleaseType
-import app.moviebase.tmdb.core.currentLocalDate
-import app.moviebase.tmdb.core.minusWeeks
-import app.moviebase.tmdb.core.plusDays
-import app.moviebase.tmdb.core.plusWeeks
 
 object DiscoverFactory {
 
@@ -21,9 +22,13 @@ object DiscoverFactory {
             is DiscoverCategory.TopRated -> createTopRated(category.mediaType)
             DiscoverCategory.AiringToday -> createAiringToday()
             DiscoverCategory.OnTv -> createOnTv()
-            is DiscoverCategory.OnDvd -> createOnDvd(category.mediaType)
+            is DiscoverCategory.OnDvd -> createOnDvd()
             is DiscoverCategory.Network -> createNetwork(category.network)
-            is DiscoverCategory.OnStreaming -> createOnStreaming(category.mediaType, category.watchProviders, category.watchRegion)
+            is DiscoverCategory.OnStreaming -> createOnStreaming(
+                category.mediaType,
+                category.watchProviders,
+                category.watchRegion,
+            )
         }
     }
 
@@ -34,10 +39,13 @@ object DiscoverFactory {
 
         val discoverTimeRange = TmdbDiscoverTimeRange.Custom(
             firstDate = firstDate.toString(),
-            lastDate = lastDate.toString()
+            lastDate = lastDate.toString(),
         )
 
-        return TmdbDiscover.Movie(releaseDate = discoverTimeRange, releaseType = TmdbReleaseType.THEATRICAL)
+        return TmdbDiscover.Movie(
+            releaseDate = discoverTimeRange,
+            withReleaseTypes = TmdbDiscoverFilter(items = setOf(TmdbReleaseType.THEATRICAL)),
+        )
     }
 
     fun createAiringToday(): TmdbDiscover.Show {
@@ -45,7 +53,7 @@ object DiscoverFactory {
 
         return TmdbDiscover.Show(
             airDateGte = localDate,
-            airDateLte = localDate
+            airDateLte = localDate,
         )
     }
 
@@ -55,20 +63,18 @@ object DiscoverFactory {
 
         return TmdbDiscover.Show(
             airDateGte = airDateGte.toString(),
-            airDateLte = airDateLte.toString()
+            airDateLte = airDateLte.toString(),
         )
     }
 
     /**
      * e. g. discover/movie?page=1&sort_by=release_date.desc&with_release_type=5
      */
-    fun createOnDvd(mediaType: TmdbMediaType): TmdbDiscover {
-        return when (mediaType) {
-            TmdbMediaType.MOVIE -> TmdbDiscover.Movie(sortBy = TmdbDiscoverMovieSortBy.RELEASE_DATE, releaseType = TmdbReleaseType.PHYSICAL)
-            TmdbMediaType.SHOW -> TmdbDiscover.Show(sortBy = TmdbDiscoverShowSortBy.FIRST_AIR_DATE, releaseType = TmdbReleaseType.PHYSICAL)
-            else -> throw IllegalArgumentException("$mediaType type is not supported for discover")
-        }
-    }
+    fun createOnDvd(): TmdbDiscover =
+        TmdbDiscover.Movie(
+            sortBy = TmdbDiscoverMovieSortBy.RELEASE_DATE,
+            withReleaseTypes = TmdbDiscoverFilter(items = setOf(TmdbReleaseType.PHYSICAL)),
+        )
 
     /**
      * e. g. discover/movie?page=1&release_date.lte=2021-05-08&language=de&sort_by=popularity.desc&region=DE&release_date.gte=2021-04-19
@@ -80,7 +86,7 @@ object DiscoverFactory {
 
         val discoverTimeRange = TmdbDiscoverTimeRange.Custom(
             firstDate = firstDate.toString(),
-            lastDate = lastDate.toString()
+            lastDate = lastDate.toString(),
         )
 
         return TmdbDiscover.Movie(releaseDate = discoverTimeRange)
@@ -108,29 +114,31 @@ object DiscoverFactory {
     fun createNetwork(network: Int): TmdbDiscover.Show {
         return TmdbDiscover.Show(
             network = network,
-            sortBy = TmdbDiscoverShowSortBy.POPULARITY
+            sortBy = TmdbDiscoverShowSortBy.POPULARITY,
         )
     }
 
-    fun createOnStreaming(mediaType: TmdbMediaType, watchProviders: List<Int>, watchRegion: String): TmdbDiscover {
+    fun createOnStreaming(mediaType: TmdbMediaType, watchProviders: TmdbDiscoverFilter<Int>, watchRegion: String): TmdbDiscover {
         return when (mediaType) {
             TmdbMediaType.MOVIE -> TmdbDiscover.Movie(
                 sortBy = TmdbDiscoverMovieSortBy.POPULARITY,
                 withWatchProviders = watchProviders,
-                watchRegion = watchRegion
+                watchRegion = watchRegion,
             )
+
             TmdbMediaType.SHOW -> TmdbDiscover.Show(
                 sortBy = TmdbDiscoverShowSortBy.POPULARITY,
                 withWatchProviders = watchProviders,
-                watchRegion = watchRegion
+                watchRegion = watchRegion,
             )
+
             else -> throw IllegalArgumentException("$mediaType type is not supported for discover")
         }
     }
 
     fun createForOneYear(mediaType: TmdbMediaType): TmdbDiscover {
         val discoverTimeRange = TmdbDiscoverTimeRange.OneYear(
-            year = currentLocalDate().year
+            year = currentLocalDate().year,
         )
 
         return when (mediaType) {

--- a/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/model/TmdbShowModel.kt
+++ b/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/model/TmdbShowModel.kt
@@ -8,24 +8,24 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-enum class TmdbShowStatus(val value: String) {
+enum class TmdbShowStatus(val value: String, val filterKey: Int) {
     @SerialName("Returning Series")
-    RETURNING_SERIES("Returning Series"),
+    RETURNING_SERIES("Returning Series", 0),
 
     @SerialName("In Production")
-    IN_PRODUCTION("In Production"),
+    IN_PRODUCTION("In Production", 2),
 
     @SerialName("Planned")
-    PLANNED("Planned"),
+    PLANNED("Planned", 1),
 
     @SerialName("Canceled")
-    CANCELED("Canceled"),
+    CANCELED("Canceled", 4),
 
     @SerialName("Ended")
-    ENDED("Ended"),
+    ENDED("Ended", 3),
 
     @SerialName("Pilot")
-    PILOT("Pilot");
+    PILOT("Pilot", 5);
 
     companion object {
         fun find(value: String?) = values().find { it.value == value }

--- a/tmdb-api/src/jvmTest/kotlin/app/moviebase/tmdb/api/TmdbDiscoverApiTest.kt
+++ b/tmdb-api/src/jvmTest/kotlin/app/moviebase/tmdb/api/TmdbDiscoverApiTest.kt
@@ -13,6 +13,8 @@ import app.moviebase.tmdb.core.currentLocalDate
 import app.moviebase.tmdb.core.mockHttpClient
 import app.moviebase.tmdb.core.plusDays
 import app.moviebase.tmdb.core.plusWeeks
+import app.moviebase.tmdb.model.TmdbDiscoverFilter
+import app.moviebase.tmdb.model.TmdbDiscoverSeparator
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
@@ -26,7 +28,7 @@ class TmdbDiscoverApiTest {
     val client = mockHttpClient(
         version = 3,
         responses = mapOf(
-            "discover/movie?page=1&language=de&region=DE&vote_count.gte=200&release_date.lte=2021-12-31&vote_average.gte=5&sort_by=popularity.desc&release_date.gte=2020-01-01"
+            "discover/movie?page=1&language=de&region=DE&vote_count.gte=200&release_date.lte=2021-12-31&vote_average.gte=5.1&sort_by=popularity.desc&release_date.gte=2020-01-01"
                 to "discover/discover_movie.json",
             "discover/movie?page=1&language=de&region=DE&with_release_type=5&sort_by=release_date.desc"
                 to "discover/discover_movie_on_dvd.json",
@@ -48,7 +50,7 @@ class TmdbDiscoverApiTest {
         val discover = TmdbDiscover.Movie(
             sortBy = TmdbDiscoverMovieSortBy.POPULARITY,
             sortOrder = TmdbSortOrder.DESC,
-            voteAverageGte = 5,
+            voteAverageGte = 5.1f,
             voteCountGte = 200,
             releaseDate = TmdbDiscoverTimeRange.BetweenYears(from = 2020, to = 2021)
         )
@@ -137,12 +139,15 @@ class TmdbDiscoverApiTest {
             category = DiscoverCategory.OnStreaming(
                 TmdbMediaType.SHOW,
                 "DE",
-                listOf(
-                    TmdbWatchProviderId.NETFLIX,
-                    TmdbWatchProviderId.AMAZON_PRIME_VIDEO,
-                    TmdbWatchProviderId.AMAZON_PRIME_VIDEO_2,
-                    TmdbWatchProviderId.DISNEY_PLUS,
-                    TmdbWatchProviderId.APPLE_TV_PLUS
+                TmdbDiscoverFilter(
+                    TmdbDiscoverSeparator.OR,
+                    listOf(
+                        TmdbWatchProviderId.NETFLIX,
+                        TmdbWatchProviderId.AMAZON_PRIME_VIDEO,
+                        TmdbWatchProviderId.AMAZON_PRIME_VIDEO_2,
+                        TmdbWatchProviderId.DISNEY_PLUS,
+                        TmdbWatchProviderId.APPLE_TV_PLUS
+                    )
                 )
             )
         )

--- a/tmdb-api/src/jvmTest/kotlin/app/moviebase/tmdb/model/TmdbDiscoverModelTest.kt
+++ b/tmdb-api/src/jvmTest/kotlin/app/moviebase/tmdb/model/TmdbDiscoverModelTest.kt
@@ -20,7 +20,9 @@ class TmdbDiscoverModelTest {
 
         @Test
         fun `it has watch providers separated by or`() {
-            val discover = TmdbDiscover.Movie(withWatchProviders = listOf(8, 9, 350))
+            val discover = TmdbDiscover.Movie(
+                withWatchProviders = TmdbDiscoverFilter(TmdbDiscoverSeparator.OR, listOf(8, 9, 350)),
+            )
 
             val parameters = discover.buildParameters()
 
@@ -29,11 +31,28 @@ class TmdbDiscoverModelTest {
 
         @Test
         fun `it has watch providers separated by and`() {
-            val discover = TmdbDiscover.Movie(withWatchProviders = listOf(8, 9, 350), withWatchProvidersType = TmdbDiscoverSeparator.AND)
+            val discover = TmdbDiscover.Movie(
+                withWatchProviders = TmdbDiscoverFilter(TmdbDiscoverSeparator.AND, listOf(8, 9, 350)),
+            )
 
             val parameters = discover.buildParameters()
 
             assertThat(parameters[DiscoverParam.WITH_WATCH_PROVIDERS]).isEqualTo("8,9,350")
+        }
+
+        @Test
+        fun `it has status separated by or`() {
+            val discover = TmdbDiscover.Movie(
+                withReleaseTypes = TmdbDiscoverFilter(
+                    TmdbDiscoverSeparator.OR,
+                    setOf(TmdbReleaseType.DIGITAL, TmdbReleaseType.PHYSICAL),
+                ),
+
+            )
+
+            val parameters = discover.buildParameters()
+
+            assertThat(parameters[DiscoverParam.Movie.WITH_RELEASE_TYPE]).isEqualTo("4|5")
         }
     }
 
@@ -46,6 +65,20 @@ class TmdbDiscoverModelTest {
             val parameters = discover.buildParameters()
 
             assertThat(parameters[DiscoverParam.WATCH_REGION]).isEqualTo("DE")
+        }
+
+        @Test
+        fun `it has status separated by or`() {
+            val discover = TmdbDiscover.Show(
+                withStatus = TmdbDiscoverFilter(
+                    TmdbDiscoverSeparator.OR,
+                    setOf(TmdbShowStatus.RETURNING_SERIES, TmdbShowStatus.PLANNED),
+                ),
+            )
+
+            val parameters = discover.buildParameters()
+
+            assertThat(parameters[DiscoverParam.Show.WITH_STATUS]).isEqualTo("0|1")
         }
     }
 }


### PR DESCRIPTION
Fix `voteAverage` type - API returns different data for `vote_average.gte=6.8` and `vote_average.gte=6.9`, you can check it via `https://api.themoviedb.org/3/discover/tv?api_key=<API_KEY>&language=en-US&sort_by=release_date.desc&vote_count.gte=50&vote_average.gte=6.8&page=1&with_status=0|3`

Added `TmdbDiscoverFilter` class, which can be used for fields with description `A comma or pipe separated list of xxxxx` in API documentation

Fix `with_release_type` for Movie Discover - for example, `with_release_type=4|5` is allowed

Add `with_status` for Show Discover instead of `with_release_type`