### PR TITLE
Fix TmdbFileImage.aspectRation

### DIFF
--- a/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/model/TmdbModel.kt
+++ b/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/model/TmdbModel.kt
@@ -185,7 +185,7 @@ data class TmdbImages(
 @Serializable
 data class TmdbFileImage(
     @SerialName("file_path") val filePath: String,
-    @SerialName("aspect_ratio") val aspectRation: Float,
+    @SerialName("aspect_ratio") val aspectRatio: Float,
     @SerialName("height") val height: Int,
     @SerialName("width") val width: Int,
     @SerialName("iso_639_1") val iso639: String? = null,

--- a/tmdb-api/src/jvmTest/kotlin/app/moviebase/tmdb/api/TmdbShowsApiTest.kt
+++ b/tmdb-api/src/jvmTest/kotlin/app/moviebase/tmdb/api/TmdbShowsApiTest.kt
@@ -120,7 +120,7 @@ class TmdbShowsApiTest {
         val poster = images.posters.first()
         assertThat(poster.height).isEqualTo(1500)
         assertThat(poster.width).isEqualTo(1000)
-        assertThat(poster.aspectRation).isEqualTo(0.667f)
+        assertThat(poster.aspectRatio).isEqualTo(0.667f)
         assertThat(poster.iso639).isEqualTo("en")
         assertThat(poster.filePath).isEqualTo("/sOUWRai0215iUSMackrZx3Y1j05.jpg")
         assertThat(poster.voteAverage).isEqualTo(5.312f)


### PR DESCRIPTION
This property was wrongly named (aspect _ration_ instead of aspect ratio).
