### PR TITLE
Improve translations API resource handling

### DIFF
--- a/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/api/TmdbCollectionsApi.kt
+++ b/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/api/TmdbCollectionsApi.kt
@@ -25,7 +25,7 @@ class TmdbCollectionsApi internal constructor(private val client: HttpClient) {
         parameterIncludeImageLanguage(includeImageLanguage)
     }.body()
 
-    suspend fun getTranslations(collectionId: Int): TmdbTranslations = client.get {
+    suspend fun getTranslations(collectionId: Int): TmdbCollectionTranslations = client.get {
         endPointV3("collection", collectionId.toString(), "translations")
     }.body()
 }

--- a/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/api/TmdbMoviesApi.kt
+++ b/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/api/TmdbMoviesApi.kt
@@ -15,12 +15,12 @@ import app.moviebase.tmdb.model.TmdbImages
 import app.moviebase.tmdb.model.TmdbKeyword
 import app.moviebase.tmdb.model.TmdbMovieDetail
 import app.moviebase.tmdb.model.TmdbMoviePageResult
+import app.moviebase.tmdb.model.TmdbMovieTranslations
 import app.moviebase.tmdb.model.TmdbPageResult
 import app.moviebase.tmdb.model.TmdbReleaseDates
 import app.moviebase.tmdb.model.TmdbResult
 import app.moviebase.tmdb.model.TmdbReview
 import app.moviebase.tmdb.model.TmdbStatusResponse
-import app.moviebase.tmdb.model.TmdbTranslations
 import app.moviebase.tmdb.model.TmdbVideo
 import app.moviebase.tmdb.model.TmdbWatchProviderResult
 import io.ktor.client.HttpClient
@@ -64,7 +64,7 @@ class TmdbMoviesApi internal constructor(private val client: HttpClient) {
     suspend fun getExternalIds(movieId: Int): TmdbExternalIds =
         client.get(moviePath(movieId, "external_ids").joinToString(separator = "/")).body()
 
-    suspend fun getTranslations(movieId: Int): TmdbTranslations =
+    suspend fun getTranslations(movieId: Int): TmdbMovieTranslations =
         client.get(moviePath(movieId, "translations").joinToString(separator = "/")).body()
 
     suspend fun getWatchProviders(movieId: Int): TmdbWatchProviderResult =

--- a/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/api/TmdbPeopleApi.kt
+++ b/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/api/TmdbPeopleApi.kt
@@ -64,7 +64,7 @@ class TmdbPeopleApi internal constructor(private val client: HttpClient) {
         parameterPage(page)
     }.body()
 
-    suspend fun getTranslations(personId: Int): TmdbTranslations = client.get {
+    suspend fun getTranslations(personId: Int): TmdbPersonTranslations = client.get {
         endPointPerson(personId, "translations")
     }.body()
 

--- a/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/api/TmdbShowApi.kt
+++ b/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/api/TmdbShowApi.kt
@@ -24,8 +24,8 @@ import app.moviebase.tmdb.model.TmdbReview
 import app.moviebase.tmdb.model.TmdbScreenedTheatrically
 import app.moviebase.tmdb.model.TmdbShowDetail
 import app.moviebase.tmdb.model.TmdbShowPageResult
+import app.moviebase.tmdb.model.TmdbShowTranslations
 import app.moviebase.tmdb.model.TmdbStatusResponse
-import app.moviebase.tmdb.model.TmdbTranslations
 import app.moviebase.tmdb.model.TmdbVideo
 import app.moviebase.tmdb.model.TmdbWatchProviderResult
 import io.ktor.client.HttpClient
@@ -56,7 +56,7 @@ class TmdbShowApi internal constructor(private val client: HttpClient) {
         parameterIncludeVideoLanguage(includeVideoLanguages)
     }.body()
 
-    suspend fun getTranslations(showId: Int): TmdbTranslations = client.get {
+    suspend fun getTranslations(showId: Int): TmdbShowTranslations = client.get {
         endPointShow(showId, "translations")
     }.body()
 

--- a/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/api/TmdbShowSeasonsApi.kt
+++ b/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/api/TmdbShowSeasonsApi.kt
@@ -32,7 +32,7 @@ class TmdbShowSeasonsApi(private val client: HttpClient) {
         parameterLanguage(language)
     }.body()
 
-    suspend fun getTranslations(showId: Int, seasonNumber: Int): TmdbTranslations = client.get {
+    suspend fun getTranslations(showId: Int, seasonNumber: Int): TmdbSeasonTranslations = client.get {
         endPointSeason(showId, seasonNumber, "translations")
     }.body()
 

--- a/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/model/TmdbCollectionModel.kt
+++ b/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/model/TmdbCollectionModel.kt
@@ -23,3 +23,12 @@ data class TmdbCollectionPageResult(
     @SerialName("total_results") override val totalResults: Int,
     @SerialName("total_pages") override val totalPages: Int
 ) : TmdbPageResult<TmdbCollection>
+
+typealias TmdbCollectionTranslations = TmdbTranslations<TmdbCollectionTranslationData>
+
+@Serializable
+data class TmdbCollectionTranslationData(
+    val title: String,
+    val overview: String,
+    val homepage: String
+)

--- a/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/model/TmdbModel.kt
+++ b/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/model/TmdbModel.kt
@@ -84,17 +84,18 @@ data class TmdbStatusResult(
 )
 
 @Serializable
-data class TmdbTranslations(
-    val id: Int,
-    val translations: List<TmdbTranslation>
+data class TmdbTranslations<out DATA>(
+    val id: Int? = null,
+    val translations: List<TmdbTranslation<DATA>>
 )
 
 @Serializable
-data class TmdbTranslation(
+data class TmdbTranslation<out DATA>(
     @SerialName("iso_3166_1") val iso3166: String,
     @SerialName("iso_639_1") val iso639: String,
     val name: String,
-    @SerialName("english_name") val englishName: String
+    @SerialName("english_name") val englishName: String,
+    @SerialName("data") val data: DATA
 )
 
 @Serializable

--- a/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/model/TmdbMovieModel.kt
+++ b/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/model/TmdbMovieModel.kt
@@ -121,6 +121,7 @@ data class TmdbMovieDetail(
     @SerialName("videos") val videos: TmdbResult<TmdbVideo>? = null,
     @SerialName("reviews") val reviews: TmdbResult<TmdbReview>? = null,
     @SerialName("images") val images: TmdbImages? = null,
+    @SerialName("translations") val translations: TmdbMovieTranslations? = null,
     @SerialName("belongs_to_collection") val belongsToCollection: TmdbBelongsToCollection? = null,
 ) : TmdbRatingItem {
 
@@ -179,4 +180,15 @@ data class TmdbAlternativeTitle(
 data class TmdbAlternativeTitles(
     @SerialName("id") val id: Int,
     @SerialName("titles") val titles: List<TmdbAlternativeTitle>,
+)
+
+typealias TmdbMovieTranslations = TmdbTranslations<TmdbMovieTranslationData>
+
+@Serializable
+data class TmdbMovieTranslationData(
+    val homepage: String,
+    val overview: String,
+    val runtime: Int,
+    val tagline: String,
+    val title: String,
 )

--- a/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/model/TmdbPeopleModel.kt
+++ b/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/model/TmdbPeopleModel.kt
@@ -198,23 +198,13 @@ data class TmdbTaggedImage(
     @SerialName("media") val media: TmdbTaggedMedia,
 )
 
-@Serializable
-data class TmdbPersonTranslations(
-    @SerialName("translations") val translations: List<TmdbPersonTranslation>,
-)
-
-@Serializable
-data class TmdbPersonTranslation(
-    @SerialName("iso_3166_1") val iso3166: String,
-    @SerialName("iso_639_1") val iso639: String,
-    @SerialName("name") val name: String,
-    @SerialName("english_name") val englishName: String,
-    @SerialName("data") val data: TmdbPersonTranslationData
-)
+typealias TmdbPersonTranslations = TmdbTranslations<TmdbPersonTranslationData>
 
 @Serializable
 data class TmdbPersonTranslationData(
-    @SerialName("biography")  val biography: String
+    @SerialName("biography")  val biography: String,
+    val name: String,
+    val primary: Boolean
 )
 
 @Serializable

--- a/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/model/TmdbShowModel.kt
+++ b/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/model/TmdbShowModel.kt
@@ -137,7 +137,19 @@ data class TmdbShowDetail(
     @SerialName("images") val images: TmdbImages? = null,
     @SerialName("reviews") val reviews: TmdbResult<TmdbReview>? = null,
     @SerialName("created_by") val createdBy: List<TmdbShowCreatedBy>? = null,
+    @SerialName("translations") val translations: TmdbShowTranslations? = null,
 ) : TmdbAnyItem, TmdbBackdropItem, TmdbPosterItem, TmdbRatingItem
+
+
+typealias TmdbShowTranslations = TmdbTranslations<TmdbShowTranslationData>
+
+@Serializable
+data class TmdbShowTranslationData(
+    val name: String,
+    val overview: String,
+    val homepage: String,
+    val tagline: String,
+)
 
 fun TmdbResult<TmdbContentRating>.getContentRating(country: String): String? =
     results.firstOrNull { it.iso3166 == country }?.rating
@@ -179,10 +191,19 @@ data class TmdbSeasonDetail(
     @SerialName("videos") val videos: TmdbResult<TmdbVideo>? = null,
     @SerialName("images") val images: TmdbImages? = null,
     @SerialName("credits") val credits: TmdbCredits? = null,
+    @SerialName("translations") val translations: TmdbSeasonTranslations? = null,
 ) : TmdbAnyItem, TmdbPosterItem {
 
     val numberOfEpisodes get() = episodeCount ?: episodes?.size ?: 0
 }
+
+typealias TmdbSeasonTranslations = TmdbTranslations<TmdbSeasonTranslationData>
+
+@Serializable
+data class TmdbSeasonTranslationData(
+    val name: String,
+    val overview: String,
+)
 
 @Serializable
 data class TmdbEpisode(
@@ -223,6 +244,7 @@ data class TmdbEpisodeDetail(
     @SerialName("crew") val crew: List<TmdbCrew>? = null,
     @SerialName("guest_stars") val guestStars: List<TmdbCast>? = null,
     @SerialName("external_ids") val externalIds: TmdbExternalIds? = null,
+    @SerialName("translations") val translations: TmdbEpisodeTranslations? = null,
 ) : TmdbAnyItem, TmdbBackdropItem, TmdbRatingItem {
     override val backdropPath: String? get() = stillPath
 }
@@ -231,4 +253,12 @@ data class TmdbEpisodeDetail(
 data class TmdbContentRating(
     @SerialName("iso_3166_1") val iso3166: String,
     @SerialName("rating") val rating: String,
+)
+
+typealias TmdbEpisodeTranslations = TmdbTranslations<TmdbEpisodeTranslationData>
+
+@Serializable
+data class TmdbEpisodeTranslationData(
+    val name: String,
+    val overview: String,
 )

--- a/tmdb-api/src/jvmTest/kotlin/app/moviebase/tmdb/api/TmdbMoviesApiTest.kt
+++ b/tmdb-api/src/jvmTest/kotlin/app/moviebase/tmdb/api/TmdbMoviesApiTest.kt
@@ -17,7 +17,7 @@ class TmdbMoviesApiTest {
     val client = mockHttpClient(
         version = 3,
         responses = mapOf(
-            "movie/10140?language=en-US&append_to_response=images,external_ids,videos,release_dates,credits,reviews,content_ratings,watch/providers"
+            "movie/10140?language=en-US&append_to_response=images,external_ids,videos,release_dates,credits,reviews,content_ratings,watch/providers,translations"
                 to "movie/movie_details_10140.json",
             "movie/10140/images?language=en"
                 to "movie/movie_images_10140.json",
@@ -57,7 +57,8 @@ class TmdbMoviesApiTest {
                 AppendResponse.CREDITS,
                 AppendResponse.REVIEWS,
                 AppendResponse.CONTENT_RATING,
-                AppendResponse.WATCH_PROVIDERS
+                AppendResponse.WATCH_PROVIDERS,
+                AppendResponse.TRANSLATIONS,
             )
         )
 
@@ -68,11 +69,18 @@ class TmdbMoviesApiTest {
         assertThat(movieDetails.voteAverage).isEqualTo(6.4f)
         assertThat(movieDetails.voteCount).isEqualTo(4534)
         assertThat(movieDetails.overview).isEqualTo("This time around Edmund and Lucy Pevensie, along with their pesky cousin Eustace Scrubb find themselves swallowed into a painting and on to a fantastic Narnian ship headed for the very edges of the world.")
+        assertThat(movieDetails.translations).isNotNull()
 
         val tmdbVideo = movieDetails.videos?.results?.first()
         assertThat(tmdbVideo).isNotNull()
         assertThat(tmdbVideo?.id).isEqualTo("54b36eb9c3a3680939006425")
         assertThat(tmdbVideo?.type).isEqualTo(TmdbVideoType.TRAILER)
+
+        val spanishTranslation = movieDetails.translations!!.translations.first { it.iso639 == "es" }
+        assertThat(spanishTranslation).isNotNull()
+        assertThat(spanishTranslation.data.title).isEqualTo("Las crónicas de Narnia: La travesía del viajero del alba")
+        assertThat(spanishTranslation.data.tagline).isEqualTo("Emprende el viaje. Vive la aventura. Descubre Narnia como nunca antes la habías visto.")
+        assertThat(spanishTranslation.data.runtime).isEqualTo(113)
     }
 
     @Test

--- a/tmdb-api/src/jvmTest/kotlin/app/moviebase/tmdb/api/TmdbPeopleApiTest.kt
+++ b/tmdb-api/src/jvmTest/kotlin/app/moviebase/tmdb/api/TmdbPeopleApiTest.kt
@@ -89,6 +89,8 @@ class TmdbPeopleApiTest {
         assertEquals(null, personDetail.externalIds?.tvdbId)
         assertEquals("", personDetail.externalIds?.twitter)
         assertEquals(null, personDetail.externalIds?.youtube)
+        val italianTranslation = personDetail.translations!!.translations.first { it.iso639 == "it" }
+        assertTrue(italianTranslation.data.biography.startsWith("Angelina Jolie è un'attrice americana"))
     }
 
     @Test

--- a/tmdb-api/src/jvmTest/kotlin/app/moviebase/tmdb/api/TmdbSeasonApiTest.kt
+++ b/tmdb-api/src/jvmTest/kotlin/app/moviebase/tmdb/api/TmdbSeasonApiTest.kt
@@ -2,6 +2,7 @@ package app.moviebase.tmdb.api
 
 import app.moviebase.tmdb.core.mockHttpClient
 import app.moviebase.tmdb.model.AppendResponse
+import com.google.common.truth.Truth.assertThat
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlinx.coroutines.test.runTest
@@ -12,7 +13,7 @@ class TmdbSeasonApiTest {
     val client = mockHttpClient(
         version = 3,
         responses = mapOf(
-            "tv/63333/season/1?append_to_response=release_dates,images,credits,tv_credits,external_ids&include_image_language="
+            "tv/63333/season/1?append_to_response=release_dates,images,credits,tv_credits,external_ids,translations&include_image_language="
                 to "tv/tv_season_63333_season_1.json",
             "tv/19849/season/1?append_to_response=credits,tv_credits"
                 to "tv/tv_season_19849_season_1.json",
@@ -47,14 +48,21 @@ class TmdbSeasonApiTest {
                 AppendResponse.CREDITS,
                 AppendResponse.TV_CREDITS,
                 AppendResponse.EXTERNAL_IDS,
+                AppendResponse.TRANSLATIONS,
             ),
             "",
         )
 
         assertEquals(68878, seasonDetails.id)
         assertNotNull(seasonDetails.images)
+        assertNotNull(seasonDetails.translations)
 
         val imageFile = seasonDetails.images?.posters?.firstOrNull()
         assertEquals("/oQasSKPcBLcEG5rOUg3s1Ozpr4s.jpg", imageFile?.filePath)
+
+        val czechTranslation = seasonDetails.translations.translations.first { it.iso639 == "cs" }
+        assertThat(czechTranslation).isNotNull()
+        assertThat(czechTranslation.data.name).isEqualTo("1. řada")
+        assertThat(czechTranslation.data.overview).isEqualTo("V první řadě se mladý saský šlechtic Uhtred promění ve válečníka, který se snaží získat zpět své území usurpované mazaným strýcem.")
     }
 }

--- a/tmdb-api/src/jvmTest/kotlin/app/moviebase/tmdb/api/TmdbShowEpisodesApiTest.kt
+++ b/tmdb-api/src/jvmTest/kotlin/app/moviebase/tmdb/api/TmdbShowEpisodesApiTest.kt
@@ -1,7 +1,6 @@
 package app.moviebase.tmdb.api
 
 import app.moviebase.tmdb.model.AppendResponse
-import app.moviebase.tmdb.model.TmdbVideoType
 import app.moviebase.tmdb.core.mockHttpClient
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
@@ -14,7 +13,7 @@ class TmdbShowEpisodesApiTest {
     val client = mockHttpClient(
         version = 3,
         responses = mapOf(
-            "tv/96677/season/1/episode/1?language=en-US&append_to_response=external_ids,videos,credits,aggregate_credits,reviews,content_ratings,watch/providers"
+            "tv/96677/season/1/episode/1?language=en-US&append_to_response=external_ids,videos,credits,aggregate_credits,reviews,content_ratings,watch/providers,translations"
                     to "tv/episode/tv_details_96677_s1e1.json",
             "tv/96677/season/1/episode/1?language=de-DE&append_to_response=images" to "tv/episode/tv_details_96677_s1e1_with_images.json"
         )
@@ -39,7 +38,8 @@ class TmdbShowEpisodesApiTest {
                     AppendResponse.AGGREGATE_CREDITS,
                     AppendResponse.REVIEWS,
                     AppendResponse.CONTENT_RATING,
-                    AppendResponse.WATCH_PROVIDERS
+                    AppendResponse.WATCH_PROVIDERS,
+                    AppendResponse.TRANSLATIONS
                 )
             )
 
@@ -50,6 +50,12 @@ class TmdbShowEpisodesApiTest {
             assertThat(episodeDetails.airDate).isEqualTo(LocalDate.parse("2021-01-08"))
             assertThat(episodeDetails.voteAverage).isEqualTo(8.189f)
             assertThat(episodeDetails.voteCount).isEqualTo(90)
+            assertThat(episodeDetails.translations).isNotNull()
+
+            val germanTranslation = episodeDetails.translations!!.translations.first { it.iso639 == "de" }
+            assertThat(germanTranslation).isNotNull()
+            assertThat(germanTranslation.data.name).isEqualTo("Kapitel 1")
+            assertThat(germanTranslation.data.overview).isEqualTo("Mit dem Diebstahl eines wertvollen Colliers will Assane eine schmerzliche alte Rechnung – und eine Schuld – begleichen. Doch der Coup nimmt eine unerwartete Wendung.")
         }
 
         @Test

--- a/tmdb-api/src/jvmTest/kotlin/app/moviebase/tmdb/api/TmdbShowsApiTest.kt
+++ b/tmdb-api/src/jvmTest/kotlin/app/moviebase/tmdb/api/TmdbShowsApiTest.kt
@@ -13,7 +13,7 @@ class TmdbShowsApiTest {
     val client = mockHttpClient(
         version = 3,
         responses = mapOf(
-            "tv/96677?language=en-US&append_to_response=external_ids,videos,credits,aggregate_credits,reviews,content_ratings,watch/providers"
+            "tv/96677?language=en-US&append_to_response=external_ids,videos,credits,aggregate_credits,reviews,content_ratings,watch/providers,translations"
                 to "tv/tv_details_96677.json",
             "tv/96677?language=de-DE&append_to_response=images" to "tv/tv_details_96677_with_images.json",
             "tv/96677/images?language=en&include_image_language=en,null" to "tv/tv_images_96677.json",
@@ -40,7 +40,8 @@ class TmdbShowsApiTest {
                     AppendResponse.AGGREGATE_CREDITS,
                     AppendResponse.REVIEWS,
                     AppendResponse.CONTENT_RATING,
-                    AppendResponse.WATCH_PROVIDERS
+                    AppendResponse.WATCH_PROVIDERS,
+                    AppendResponse.TRANSLATIONS
                 )
             )
 
@@ -51,6 +52,7 @@ class TmdbShowsApiTest {
             assertThat(showDetails.voteCount).isEqualTo(742)
             assertThat(showDetails.homepage).isEqualTo("https://www.netflix.com/title/80994082")
             assertThat(showDetails.overview).isEqualTo("Inspired by the adventures of Arsène Lupin, gentleman thief Assane Diop sets out to avenge his father for an injustice inflicted by a wealthy family.")
+            assertThat(showDetails.translations).isNotNull()
 
             val tmdbVideo = showDetails.videos?.results?.first()
             assertThat(tmdbVideo).isNotNull()
@@ -61,6 +63,11 @@ class TmdbShowsApiTest {
             assertThat(network).isNotNull()
             assertThat(network.name).isEqualTo("Netflix")
             assertThat(network.logoPath).isEqualTo("/wwemzKWzjKYJFfCeiB57q3r4Bcm.png")
+
+            val lithuanianTranslation = showDetails.translations!!.translations.first { it.iso639 == "lt" }
+            assertThat(lithuanianTranslation).isNotNull()
+            assertThat(lithuanianTranslation.data.name).isEqualTo("Lupenas")
+            assertThat(lithuanianTranslation.data.overview).isEqualTo("Įkvėptas Arsenijaus Lupeno nuotykių, ponas vagis Asanas Diopas siekia atkeršyti turtuolių šeimai už neteisingumą prieš jo tėvą.")
         }
 
         @Test

--- a/tmdb-api/src/jvmTest/resources/tmdb3/movie/movie_details_10140.json
+++ b/tmdb-api/src/jvmTest/resources/tmdb3/movie/movie_details_10140.json
@@ -91,9 +91,7 @@
         "width": 3840
       }
     ],
-    "logos": [
-
-    ],
+    "logos": [],
     "posters": [
       {
         "aspect_ratio": 0.667,
@@ -5064,5 +5062,581 @@
         ]
       }
     }
+  },
+  "translations": {
+    "translations": [
+      {
+        "iso_3166_1": "US",
+        "iso_639_1": "en",
+        "name": "English",
+        "english_name": "English",
+        "data": {
+          "homepage": "",
+          "overview": "This time around Edmund and Lucy Pevensie, along with their pesky cousin Eustace Scrubb find themselves swallowed into a painting and on to a fantastic Narnian ship headed for the very edges of the world.",
+          "runtime": 113,
+          "tagline": "Return to magic. Return to hope. Return to Narnia.",
+          "title": ""
+        }
+      },
+      {
+        "iso_3166_1": "DE",
+        "iso_639_1": "de",
+        "name": "Deutsch",
+        "english_name": "German",
+        "data": {
+          "homepage": "http://www.narnia.com/de/",
+          "overview": "Die Geschwister Edmund und Lucy verbringen einen langen, lausigen Sommer bei ihrem unausstehlich besserwisserischen Cousin Eustacius Knilch. Ihre bedauerliche, an Abenteuern arme Lage ändert sich, als sie von einem Gemälde verschlungen und auf das Schiff Morgenröte, dass den Ozean von Narnia druchquert, gespült werden. Dort treffen sie auf alte Bekannte: Ihr blaublütiger Freund Kaspian und die Krieger-Maus Reepicheep warten schon auf sie. Gemeinsam werden sie von dem Löwen Aslan auf eine geheimnissvolle Mission geschickt...",
+          "runtime": 113,
+          "tagline": "Rückkehr zur Magie. Rückkehr zur Hoffnung. Rückkehr nach Narnia",
+          "title": "Die Chroniken von Narnia: Die Reise auf der Morgenröte"
+        }
+      },
+      {
+        "iso_3166_1": "RU",
+        "iso_639_1": "ru",
+        "name": "Pусский",
+        "english_name": "Russian",
+        "data": {
+          "homepage": "",
+          "overview": "Эдмунд, Люси, их кузен Юстас и король Каспиан отплывают на корабле «Покоритель Зари» на поиски друзей отца Каспиана - семи лордов: Ревелиана, Берна, Аргоза, Мавроморна, Октезиана, Рестимара и Рупа, изгнанных во время недолгого правления тирана Мираза...",
+          "runtime": 112,
+          "tagline": "«Назад в Волшебство! Назад к Надежде! Назад в Нарнию!»",
+          "title": "Хроники Нарнии: Покоритель Зари"
+        }
+      },
+      {
+        "iso_3166_1": "FR",
+        "iso_639_1": "fr",
+        "name": "Français",
+        "english_name": "French",
+        "data": {
+          "homepage": "",
+          "overview": "Happés à l’intérieur d’un intriguant tableau, Edmund et Lucy Pevensie, ainsi que leur détestable cousin Eustache, se retrouvent subitement projetés dans le royaume de Narnia, à bord d’un navire majestueux : le Passeur d’Aurore. Rejoignant Caspian, devenu roi, et l’intrépide souris guerrière Ripitchip, ils embarquent pour une périlleuse mission dont dépend le sort même de Narnia. À la recherche de sept seigneurs disparus, nos voyageurs entament un envoûtant périple vers les îles mystérieuses de l’Est, où ils ne manqueront pas de rencontrer tant de créatures magiques que de merveilles inimaginables. Mais ils devront surtout vaincre leurs peurs les plus profondes en affrontant de sinistres ennemis, tout en résistant à de terribles tentations auxquelles ils seront confrontés. Il est temps pour eux de faire preuve d’un courage légendaire au cours d’une odyssée qui les transformera à jamais et les emportera au bout du monde, où le grand Lion Aslan les attend.",
+          "runtime": 115,
+          "tagline": "Retrouvez LA MAGIE. Retrouvez L'AVENTURE. Retournez à NARNIA.",
+          "title": "Le Monde de Narnia : L'Odyssée du passeur d'aurore"
+        }
+      },
+      {
+        "iso_3166_1": "ES",
+        "iso_639_1": "es",
+        "name": "Español",
+        "english_name": "Spanish",
+        "data": {
+          "homepage": "http://peliculasmegahdd.net/",
+          "overview": "Tercera entrega de la saga literaria creada por C.S. Lewis. En esta ocasión, los hermanos Edmund y Lucy Pevensie y su primo Eustace embarcan en la nave \"El Viajero del Alba\" para buscar a los siete caballeros que han sido expulsados del reino por Miraz, el usurpador del trono de Narnia.",
+          "runtime": 113,
+          "tagline": "Emprende el viaje. Vive la aventura. Descubre Narnia como nunca antes la habías visto.",
+          "title": "Las crónicas de Narnia: La travesía del viajero del alba"
+        }
+      },
+      {
+        "iso_3166_1": "IT",
+        "iso_639_1": "it",
+        "name": "Italiano",
+        "english_name": "Italian",
+        "data": {
+          "homepage": "https://www.narnia.com/uk",
+          "overview": "Edmund e Lucy Pevensie vengono inghiottiti con il cugino Eustace in un quadro e portati a Narnia su un fantastico veliero. Lì si uniscono al principe Caspian, ora re, e al topo guerriero Reepicheep in una missione da cui dipende il destino della stessa Narnia: la ricerca dei sette signori perduti di Narnia, che Caspian ha promesso al \"Gran Leone\" Aslan di ritrovare. I nostri eroi questa volta dovranno raggiungere i confini del Mondo attraversando oceani e terre lontane e scontrandosi con creature sinistre per salvare la loro amata Narnia da un destino avverso.",
+          "runtime": 112,
+          "tagline": "La magia di una grande e spettacolare avventura illuminerà il tuo Natale.",
+          "title": "Le cronache di Narnia - Il viaggio del veliero"
+        }
+      },
+      {
+        "iso_3166_1": "CN",
+        "iso_639_1": "zh",
+        "name": "普通话",
+        "english_name": "Mandarin",
+        "data": {
+          "homepage": "",
+          "overview": "爱德蒙和妹妹露西以及常闯祸的表哥尤斯提意外进入油画中的纳尼亚世界，并登上航行中的“黎明踏浪号”。 在这艘船上，他们和已成为国王的凯斯宾王子和老鼠长“老脾气”重逢。凯斯宾此行的任务，是必须要寻找以前被叛徒叔叔放逐的忠心老臣们。在这次冒险中，他们不但与老朋友亚斯蓝相逢，更结识了新朋友，包括受到诅咒而蹦蹦跳跳的蹩独脚仙、为大家指点迷津身穿红袍的柯瑞金魔法师、会喷火的飞龙、插入亚斯蓝之桌就会发挥超强能量的亚斯蓝之剑、以及拥有神奇力量的魔法书等…凭着勇气和毅力，他们不但突破一关又一关的挑战，也为彼此的生命写下了惊奇!",
+          "runtime": 0,
+          "tagline": "",
+          "title": "纳尼亚传奇3：黎明踏浪号"
+        }
+      },
+      {
+        "iso_3166_1": "FI",
+        "iso_639_1": "fi",
+        "name": "suomi",
+        "english_name": "Finnish",
+        "data": {
+          "homepage": "",
+          "overview": "Huikeassa koko perheen fantasiaseikkailussa palataan takaisin tarunhohtoiseen ja upeaan C.S. Lewisin luomaan Narnia-maailmaan – tällä kertaa meriaiheisen taulun kautta. Edmund (Skandar Keynes) ja Lucy Pevensie (Georgie Henley) ovat viettämässä kesälomaansa, kun he löytävät serkkunsa Eustancen (Will Poulter) kanssa taulun, joka toimii porttina Narnia-maailmaan ja Sarastus-laivalle (The Dawn Treader). Jälleen uusi valloittava seikkailu odottaa heitä ja heidän kuninkaallista ystäväänsä prinssi Kaspiania (Ben Barnes).",
+          "runtime": 115,
+          "tagline": "",
+          "title": "Narnian tarinat: Kaspianin matka maailman ääriin"
+        }
+      },
+      {
+        "iso_3166_1": "CZ",
+        "iso_639_1": "cs",
+        "name": "Český",
+        "english_name": "Czech",
+        "data": {
+          "homepage": "",
+          "overview": "Edmund a Lucinka, dvě nejmladší z dětí Pevensieových, tráví prázdniny u svých příbuzných společně se svým nesnesitelným bratrancem Eustacem. Často tu vzpomínají na Narnii a na dobrodužství, které tam zažili, když jednoho dne z ničeho nic ožije obraz lodi, který visí v Lucinčině pokoji a oni se skrz něj dostávají zpátky do Narnie. Bohužel i s bratrancem Eustacem. Z moře, kam se pomocí obrazu přenesli, je zachraňuje král Kaspian desátý, kterému děti v předchozím díle, společně se sourozenci Petrem a Zuzanou, pomohly ke královskému trůnu. Nyní se mladý král na své lodi s podivným názvem Jitřní Poutník vydává splnit svou přísahu a najít sedm ztracených lordů z Narnie, kteří se kdysi dávno ztratili během nebezpečné výpravy. Pevensieovi si samozřejmě takové dobrodružství nemohou nechat ujít, jsou štastni, že jsou zpět v kouzelném království, a tak opět stanou po Kaspianově boku a plují s ním podél nebezpečných ostrovů, ale také přátelskými vodami a všude zažívají veliká dobrodužství.",
+          "runtime": 108,
+          "tagline": "Návrat k magii. Návrat k naději. Návrat do Narnie.",
+          "title": "Letopisy Narnie: Plavba Jitřního poutníka"
+        }
+      },
+      {
+        "iso_3166_1": "TR",
+        "iso_639_1": "tr",
+        "name": "Türkçe",
+        "english_name": "Turkish",
+        "data": {
+          "homepage": "",
+          "overview": "Cambridge-İngiltere’de İkinci Dünya Savaşı sırasında Pevensie kardeşler, sinir bozucu kuzenleri Eustace Clarence Scrubb’ın evinde kalmalarıyla başlarlar. Bir gün çocukların üçü de, açık denizde duran bir geminin resmedildiği tablonun içine çekilirler. Kendilerini okyanusun altında bulan çocuklar gözleri önündeki görkemli Şafak Yıldızı’nı görmek için su yüzüne çıkarlar; artık Caspian ve Reepicheep ile beraberdirler. Caspian’ın görevi, kötü amcası tarafından sürgün edilen yedi soylu Telmarlı Narnia Lordu’nun akıbetini keşfetmektir ve Pevensie kardeşler, Eustace ve Reepicheep de ona yardım ederler. Büyüleyici macera boyunca sihirli Dufflepudlarla, kötü niyetli köle tüccarları, ejderhalar ve büyülü mer halkıyla baş etmek zorundadırlar. Narnia’nın geleceği tehlikededir...",
+          "runtime": 0,
+          "tagline": "",
+          "title": "Narnia Günlükleri: Şafak Yıldızının Yolculuğu"
+        }
+      },
+      {
+        "iso_3166_1": "SK",
+        "iso_639_1": "sk",
+        "name": "Slovenčina",
+        "english_name": "Slovak",
+        "data": {
+          "homepage": "",
+          "overview": "Peter a Susan sú už na návrat do Narnie pristarí, a tak sa cez magický obraz dostávajú iba Edmund a Lucy. Nechtiac so sebou priberú aj veľmi nepríjemného bratanca Eustacea, ktorý sa však pobytom v Narnii zmení na nepoznanie. Podobne ako predtým Edmundovi, aj jemu hrozí smrteľné nebezpečenstvo. Kráľ Kaspián spolu s myšiakom Reepicheepom sa vydávajú na dobrodružnú výpravu. Jej cieľom je nájsť sedem šľachticov, ktorých strýko Miraz poslal na smrť v diaľavách.",
+          "runtime": 113,
+          "tagline": "",
+          "title": "Narnia: Dobrodružstvá lode Ranný pútnik"
+        }
+      },
+      {
+        "iso_3166_1": "HU",
+        "iso_639_1": "hu",
+        "name": "Magyar",
+        "english_name": "Hungarian",
+        "data": {
+          "homepage": "",
+          "overview": "A Pevensie-gyerekek körül a leghétköznapibb dolgok is csodává válnak. Ezúttal egy festménnyel kezdődik minden: a vásznon árválkodó hajó életre kel, és Lucy, Edmund és a kissé elviselhetetlen unokatestvérük az óceánba zuhannak. Szerencsére a Hajnalvándor legénysége kimenti őket és így az ifjú kalandoroknak egyre újabb, izgalmasabb és veszélyesebb próbákat kell kiállniuk. A hajó és rajta Caspian király Narnia hét elveszett urát keresi a Magányos Szigetek környékén, ahol rabszolga-kereskedők, trónbitorlók, tengeri viharok, a mélység fenekén élő szörnyek és láthatatlan lények várnak az expedíció tagjaira. Narnia mesés teremtményei az angol gyerekek segítsége nélkül ismét benne volnának a slamasztikában!",
+          "runtime": 113,
+          "tagline": "",
+          "title": "Narnia krónikái: A Hajnalvándor útja"
+        }
+      },
+      {
+        "iso_3166_1": "NL",
+        "iso_639_1": "nl",
+        "name": "Nederlands",
+        "english_name": "Dutch",
+        "data": {
+          "homepage": "",
+          "overview": "Edmund en Lucy moeten heel de zomer bij hun vervelende neefje Eustace verblijven, wat ze niet leuk vinden. Terwijl ze op een dag, samen met Eustace in een kamer zitten, komt een schilderij met het schip de 'Dawn Treader' erop tot leven en voor ze het weten bevinden ze zich op het magische schip. Daar ontmoeten ze hun vriend, koning Caspian.",
+          "runtime": 113,
+          "tagline": "",
+          "title": "De Kronieken van Narnia: De Reis van het Drakenschip"
+        }
+      },
+      {
+        "iso_3166_1": "SE",
+        "iso_639_1": "sv",
+        "name": "svenska",
+        "english_name": "Swedish",
+        "data": {
+          "homepage": "",
+          "overview": "Genom en magisk tavla transporteras syskonen Lucy och Edmund återigen till landet Narnia, denna gång med deras odrägliga kusin Eustace i släptåg. Väl där återförenas de med Kung Caspian ombord på det mäktiga skeppet Gryningen. I Narnia hotar en ondskefull dimma att sluka landet och med hjälp av Caspian, musen Ripipip och resten av den modiga besättningen måste Lucy, Edmund och Eustace slåss mot nya faror för att återigen rädda landet från undergång.",
+          "runtime": 113,
+          "tagline": "",
+          "title": "Narnia: Kung Caspian och skeppet Gryningen"
+        }
+      },
+      {
+        "iso_3166_1": "PT",
+        "iso_639_1": "pt",
+        "name": "Português",
+        "english_name": "Portuguese",
+        "data": {
+          "homepage": "",
+          "overview": "As personagens da extraordinária história criada pelo irlandês C.S. Lewis voltam a ganhar vida na terceira aventura da série \"As Crónicas de Nárnia\". Através de um estranho quadro, Lucy e Edmund Pevensie (Georgie Henley e Skandar Keynes), na companhia do seu antipático primo Eustace (Will Poulter), são transportados através de Inglaterra para o mundo mágico de Nárnia onde reencontram o outrora príncipe Caspian (Ben Barnes), agora soberano. A bordo do Caminheiro da Alvorada, um navio colossal, farão uma excitante e perigosa viagem a umas ilhas misteriosas, o que será, uma vez mais, um enorme teste à sua coragem e autodomínio. E, no fim da jornada, algo de muito importante estará à sua espera...",
+          "runtime": 127,
+          "tagline": "Regresse à magia. Regresse à esperança. Regresse a Nárnia.",
+          "title": "As Crónicas de Nárnia: A Viagem do Caminheiro da Alvorada"
+        }
+      },
+      {
+        "iso_3166_1": "DK",
+        "iso_639_1": "da",
+        "name": "Dansk",
+        "english_name": "Danish",
+        "data": {
+          "homepage": "",
+          "overview": "Nye eventyr venter Edmund og Lucy Pevensie. Sammen med deres fætter Eustace og deres fælles royale ven, Prins Caspian går de ombord på skibet ’The Dawn Treader’. Her forsvinder de ind i et mystisk og magisk maleri og firkløveret er nu pludselig blevet kastet ud i en faretruende mission, hvor de er nødt til at samle alt deres mod. For Narnias skæbne afhænger udelukkende af deres mod og evner.",
+          "runtime": 113,
+          "tagline": "",
+          "title": "Narnia: Morgenvandrerens rejse"
+        }
+      },
+      {
+        "iso_3166_1": "PL",
+        "iso_639_1": "pl",
+        "name": "Polski",
+        "english_name": "Polish",
+        "data": {
+          "homepage": "",
+          "overview": "Trzecia z cyklu ekranizacji słynnych książek C.S. Lewisa, zrealizowana w cyfrowej technice 3D.  Widowiskowa opowieść o wyprawie rodzeństwa Pevensie i księcia Kaspiana, którzy na pokładzie statku zwanego \"Wędrowcem do Świtu\" docierają do krainy, z której pochodzi lew Aslan.",
+          "runtime": 113,
+          "tagline": "Wybierz się w podróż. Przeżyj przygodę. Odkryj Narnię, jakiej nigdy nie widziałeś.",
+          "title": "Opowieści z Narnii: Podróż Wędrowca do Świtu"
+        }
+      },
+      {
+        "iso_3166_1": "NO",
+        "iso_639_1": "nb",
+        "name": "Bokmål",
+        "english_name": "Norwegian Bokmål",
+        "data": {
+          "homepage": "",
+          "overview": "",
+          "runtime": 113,
+          "tagline": "",
+          "title": "Legenden om Narnia - Reisen til det ytterste hav"
+        }
+      },
+      {
+        "iso_3166_1": "NO",
+        "iso_639_1": "no",
+        "name": "Norsk",
+        "english_name": "Norwegian",
+        "data": {
+          "homepage": "",
+          "overview": "Edmund og Lucy Pevensie, samt deres fetter Eustace blir via et maleri transportert tilbake til Narnia og det fantastiske skipet \"Morgenrødmens Vind\". De blir med Prins Caspian og den fryktløse musen Ripipip på et tokt som Narnias skjebne er avhengig av. Den modige gruppen møter fristelser de må kjempe i mot når de beveger seg til de mystiske øyene i Narnia. De blir konfrontert med magiske skikkelser og skumle fiender til de endelig møter deres venn og beskytter, Aslan.",
+          "runtime": 113,
+          "tagline": "",
+          "title": "Legenden om Narnia - Reisen til det ytterste hav"
+        }
+      },
+      {
+        "iso_3166_1": "BG",
+        "iso_639_1": "bg",
+        "name": "български език",
+        "english_name": "Bulgarian",
+        "data": {
+          "homepage": "",
+          "overview": "Едмънд и Луси Певънзи, заедно с досадния си братовчед Юстис Скръб, влизат отново в света на Нарния, този път погълнати от картина. Тримата се оказват на фантастичен кораб, запътил се към самия край на света. Обединявайки сили за пореден път с техния приятел Принц Каспиян и мишката боец, Рийпчийп, героите са изпратени на мистериозна мисия към Самотните Острови и отвъд. Там те се изправят срещу магически Дъфълпъди (митични същества с 1 крак), зловещи търговци на роби, дракони и водни хуманоиди.",
+          "runtime": 113,
+          "tagline": "Завърнете се при магията на Нарния",
+          "title": "Хрониките на Нарния: Плаването на \"Разсъмване\""
+        }
+      },
+      {
+        "iso_3166_1": "GR",
+        "iso_639_1": "el",
+        "name": "ελληνικά",
+        "english_name": "Greek",
+        "data": {
+          "homepage": "http://www.narnia.com/",
+          "overview": "Ο Έντμουντ και η Λούσι, μαζί με τον ξάδερφό τους Γιουστέις, τον μεγαλοπρεπή φίλο τους Κάσπιαν και ένα ριψοκίνδυνο ποντίκι με το όνομα Ρίπιτσιπ, βρίσκονται ξαφνικά μέσα σε έναν πίνακα και στο πλοίο Dawn Treader. Η αποστολή τους - από την οποία εξαρτάται η μοίρα ολόκληρης της Νάρνια - θα τους οδηγήσει σε μυστηριώδη νησιά, σε μοιραίες αναμετρήσεις με μαγικά πλάσματα και απειλητικούς εχθρούς, αλλά και στην επανασύνδεση με τον φίλο και προστάτη τους, το λιοντάρι Άσλαν.",
+          "runtime": 115,
+          "tagline": "Κάντε το ταξίδι. Ζήστε την περιπέτεια. Ανακαλύψτε τη Νάρνια όπως δεν την έχετε ξαναδεί.",
+          "title": "Το Χρονικό της Νάρνια: Ο Ταξιδιώτης της Αυγής"
+        }
+      },
+      {
+        "iso_3166_1": "KR",
+        "iso_639_1": "ko",
+        "name": "한국어/조선말",
+        "english_name": "Korean",
+        "data": {
+          "homepage": "",
+          "overview": "2차 세계대전이 한창인 영국. 페번시가의 막내들인 에드먼드(스캔다 케인스)와 루시(조지 헨리)는 까탈스럽고 불평 많은 사촌 유스터스(윌 폴터)의 집에 얹혀살고 있다. 어느 날 루시의 방에 걸려 있는 그림 속에서 갑자기 바닷물이 쏟아져 나오며 세 아이는 나니아의 세계로 빨려들어간다. 그들이 망망대해에서 만난 것은 새벽 출정호를 타고 실종된 일곱명의 영주를 찾아 헤매던 캐스피언 왕자(벤 반스) 일행. 이들은 첫 번째 항해지인 론 제도의 영주 베른에게, 아슬란에게서 받은 일곱개의 마법검을 소유한 일곱명의 영주가 사라지면서 언제부터인가 바다에서 녹색 안개가 나타나 배와 사람들을 집어삼켜왔다는 사실을 전해듣는다.",
+          "runtime": 0,
+          "tagline": "위협적인 녹색 안개의 유혹에 얽힌 미스터리",
+          "title": "나니아 연대기: 새벽 출정호의 항해"
+        }
+      },
+      {
+        "iso_3166_1": "IL",
+        "iso_639_1": "he",
+        "name": "עִבְרִית",
+        "english_name": "Hebrew",
+        "data": {
+          "homepage": "",
+          "overview": "הדמויות שבתמונה החלו לנוע לפתע. הגלים געשו, חרטום האונייה עלה וירד, והקצף הכה בפניהם של אדמונד, לוסי ויוסטס. לא עבר רגע והשלושה מצאו את עצמם על סיפונה של האונייה המלכותית \"דורך השחר\", שם הם פגשו את כספיאן, מלכה הצעיר של נרניה, ואת האביר הנועז, העכבר ריפיצ'יפ. יחד הם יוצאים למסע בעקבות שבעת הלורדים שגורשו מנרניה על ידי המלך מירז האכזר. הרפתקאות מופלאות מחכות להם בלב ים, שעה שהם מפליגים הרחק אל האיים הנידחים שבמזרח, ומעבר להם אל המקום שבו לא ביקר איש לפניהם, אל ממלכתו של האריה האגדי אסלן, שבסוף העולם.",
+          "runtime": 0,
+          "tagline": "",
+          "title": "סיפורי נרניה: המסע בדורך השחר"
+        }
+      },
+      {
+        "iso_3166_1": "JP",
+        "iso_639_1": "ja",
+        "name": "日本語",
+        "english_name": "Japanese",
+        "data": {
+          "homepage": "",
+          "overview": "両親と上の兄姉が渡米中、エドマンドとルーシーのペベンシー兄妹はいとこのユースチスの家に預けられた。ある時、壁に掛けられた船の絵を見ていた3人は、突然動き出した絵の中に吸い込まれ、ナルニアの海へと放り出された。王となったカスピアンやネズミの騎士リーピチープが乗る船・朝びらき丸に救われた彼らは、懐かしい友人たちとの再会を喜ぶ間もなく、ナルニアを悪から守る7つの魔法の剣を探す冒険に加わることになる。",
+          "runtime": 112,
+          "tagline": "誰も知らないナルニアへ。",
+          "title": "ナルニア国物語／第3章：アスラン王と魔法の島"
+        }
+      },
+      {
+        "iso_3166_1": "RO",
+        "iso_639_1": "ro",
+        "name": "Română",
+        "english_name": "Romanian",
+        "data": {
+          "homepage": "",
+          "overview": "De data aceasta, Edmund și Lucy Pevensie, împreună cu vărul lor enervant, Eustace Scrubb, se trezesc înghițiți într-un tablou și urcați pe o navă narniană fantastică care se îndreaptă spre marginile lumii.",
+          "runtime": 0,
+          "tagline": "Întoarcerea la magie. Întoarcerea la speranță. Întoarcerea la Narnia.",
+          "title": "Cronicile din Narnia: Călătoria pe mare cu Zori de Zi"
+        }
+      },
+      {
+        "iso_3166_1": "BR",
+        "iso_639_1": "pt",
+        "name": "Português",
+        "english_name": "Portuguese",
+        "data": {
+          "homepage": "",
+          "overview": "Lúcia, Edmundo e Eustáquio retornam para Nárnia, onde encontram com príncipe Caspian, agora rei, e outros amigos. Buscando os Sete Fidalgos Desaparecidos de Telmar, eles começam uma nova aventura a bordo do navio Peregrino da Alvorada e irão encarar guerreiros, dragões, anões e tritões.",
+          "runtime": 113,
+          "tagline": "Embarque nessa viagem. Viva a aventura.",
+          "title": "As Crônicas de Nárnia: A Viagem do Peregrino da Alvorada"
+        }
+      },
+      {
+        "iso_3166_1": "UA",
+        "iso_639_1": "uk",
+        "name": "Український",
+        "english_name": "Ukrainian",
+        "data": {
+          "homepage": "",
+          "overview": "Едмунд, Люсі, їхній кузен Юстас і король Каспіан відпливають на кораблі «Підкорювач світанку» на пошуки друзів батька Каспіана — семи лордів: Ревеліана, Берна, Арґоса, Мавроморна, Октезіана, Рестімара та Рупа, вигнаних під час недовгого правління тирана Міраза...",
+          "runtime": 0,
+          "tagline": "Повернення до магії. Повернення до надії. Повернення до Нарнії.",
+          "title": "Хроніки Нарнії: Підкорювач світанку"
+        }
+      },
+      {
+        "iso_3166_1": "CA",
+        "iso_639_1": "fr",
+        "name": "Français",
+        "english_name": "French",
+        "data": {
+          "homepage": "",
+          "overview": "Happés à l’intérieur d’un intriguant tableau, Edmund et Lucy Pevensie, ainsi que leur détestable cousin Eustache, se retrouvent subitement projetés dans le royaume de Narnia, à bord d’un navire majestueux : le Passeur d’Aurore. Rejoignant Caspian, devenu roi, et l’intrépide souris guerrière Ripitchip, ils embarquent pour une périlleuse mission dont dépend le sort même de Narnia. À la recherche de sept seigneurs disparus, nos voyageurs entament un envoûtant périple vers les îles mystérieuses de l’Est, où ils ne manqueront pas de rencontrer tant de créatures magiques que de merveilles inimaginables. Mais ils devront surtout vaincre leurs peurs les plus profondes en affrontant de sinistres ennemis, tout en résistant à de terribles tentations auxquelles ils seront confrontés. Il est temps pour eux de faire preuve d’un courage légendaire au cours d’une odyssée qui les transformera à jamais et les emportera au bout du monde, où le grand Lion Aslan les attend.",
+          "runtime": 113,
+          "tagline": "Retouvez LA MAGIE. Retrouvez L'AVENTURE. Retournez à NARNIA.",
+          "title": "Les Chroniques de Narnia : L'Odyssée du Passeur d'Aurore"
+        }
+      },
+      {
+        "iso_3166_1": "ES",
+        "iso_639_1": "ca",
+        "name": "Català",
+        "english_name": "Catalan",
+        "data": {
+          "homepage": "",
+          "overview": "Tercer lliurament de la saga literària creada per C.S. Lewis. Els germans Edmund i Lucy Pevensie i el seu cosí Eustace s'embarquen en la nau “El Viatger de l'Alba” per buscar els set cavallers que han estat expulsats del regne per Miraz.",
+          "runtime": 0,
+          "tagline": "",
+          "title": "Les cròniques de Nàrnia: La travessa del viatger de l’alba"
+        }
+      },
+      {
+        "iso_3166_1": "LV",
+        "iso_639_1": "lv",
+        "name": "Latviešu",
+        "english_name": "Latvian",
+        "data": {
+          "homepage": "",
+          "overview": "",
+          "runtime": 0,
+          "tagline": "",
+          "title": "Nārnijas hronikas: Rītausmas iekarotājs"
+        }
+      },
+      {
+        "iso_3166_1": "TW",
+        "iso_639_1": "zh",
+        "name": "普通话",
+        "english_name": "Mandarin",
+        "data": {
+          "homepage": "",
+          "overview": "愛德蒙和妹妹露西以及常闖禍的表哥尤斯提意外被牆上的油畫捲入其中，來到畫中的“黎明行者號”，在這艘船上，他們和成為國王的賈斯潘王子和老鼠勇士雷佩契普重逢。  賈斯潘此行的目的，要尋找以前被叛徒叔叔放逐的忠心老臣們，在這次任務中，他們也得償宿願的遇見了老朋友—亞斯藍! 憑著勇氣和毅力，他們再一次共同對抗惡勢力，穿越一關又一關的冒險挑戰，並且還有更多神奇的事物在等著他們，這趟未知的旅程又會為彼此的生命寫下什麼驚奇的故事呢？",
+          "runtime": 113,
+          "tagline": "魔法再起 冒險啟航 進入前所未見的納尼亞",
+          "title": "納尼亞傳奇：黎明行者號"
+        }
+      },
+      {
+        "iso_3166_1": "HK",
+        "iso_639_1": "zh",
+        "name": "普通话",
+        "english_name": "Mandarin",
+        "data": {
+          "homepage": "",
+          "overview": "《黎明行者號》中，艾文及露西加上麻煩表兄弟尤達斯，突然被姨媽家中房間牆上一幅航海油畫吸走，當驚魂未定時他們已霎眼間匯合登基成功的卡斯柏王子，搭乘其『黎明行者號』航海啟程，一同出海尋找坦摩七勳爵。巨船在茫茫大海中經歷重重驚險難關，大小邪魔紛紛出籠搗亂，滿途荊棘。他們發現每個島嶼上多個誘人秘密，從聯串意外中瞭解到一定要團結一致，憑著勇氣及膽識才能破解危機，走到世界盡頭完成不可能的任務，解救納尼亞的危機﹗",
+          "runtime": 0,
+          "tagline": "",
+          "title": "魔幻王國：黎明行者號"
+        }
+      },
+      {
+        "iso_3166_1": "MX",
+        "iso_639_1": "es",
+        "name": "Español",
+        "english_name": "Spanish",
+        "data": {
+          "homepage": "",
+          "overview": "Tercera entrega de la saga literaria creada por C.S. Lewis. En esta ocasión, los hermanos Edmund y Lucy Pevensie y su primo Eustace embarcan en la nave \"El Viajero del Alba\" para buscar a los siete caballeros que han sido expulsados del reino por Miraz, el usurpador del trono de Narnia.",
+          "runtime": 115,
+          "tagline": "Emprende el viaje. Vive la aventura. Descubre Narnia como nunca antes la habías visto.",
+          "title": "Las Crónicas de Narnia 3: La Travesía del Viajero del Alba"
+        }
+      },
+      {
+        "iso_3166_1": "TH",
+        "iso_639_1": "th",
+        "name": "ภาษาไทย",
+        "english_name": "Thai",
+        "data": {
+          "homepage": "",
+          "overview": "อภินิหารตำนานแห่งนาร์เนีย: ผจญภัยโพ้นทะเล มหกรรมภาพยนตร์สำหรับฤดูกาลวันหยุด เอ็ดมันด์ และลูซี่ พีเวนซี่ พร้อมกับยูซตาสลูกพี่ลูกน้องของพวกเขาถูกดูดกลืนเข้าไปยังภาพวาด ถูกส่งกลับไปยังนาร์เนียและเรือดอว์น เทรดเดอร์อันงดงาม พวกเขาร่วมมือกับกษัตริย์แคสเปี้ยน และหนูนักรบผู้มีนามว่า รีปพิชีป เพื่อภารกิจที่กุมชะตาแห่งนาร์เนียเอาไว้ เหล่านักเดินทางผู้กล้าผ่านพ้นสิ่งล่อตาล่อใจอันยิ่งใหญ่ เมื่อพวกเขาเดินทางไปยังเกาะลึกลับต่าง ๆ มีการเผชิญหน้าอย่างเอาเป็นเอาตายกับสิ่งมีชีวิตแห่งเวทมนตร์ และเหล่าศัตรูผู้ชั่วร้าย รวมไปถึงการกลับมารวมตัวกับเพื่อนและผู้คุ้มกันของพวกเขาอย่าง ราชสีห์ผู้ยิ่งใหญ่ อัสลาน",
+          "runtime": 115,
+          "tagline": "อภินิหารตำนานแห่งนาร์เนีย ตอน ผจญภัยโพ้นทะเล",
+          "title": "อภินิหารตำนานแห่งนาร์เนีย ตอน ผจญภัยโพ้นทะเล"
+        }
+      },
+      {
+        "iso_3166_1": "RS",
+        "iso_639_1": "sr",
+        "name": "Srpski",
+        "english_name": "Serbian",
+        "data": {
+          "homepage": "",
+          "overview": "Едмунд и Луси Певенси, заједно с рођаком Еустахијем, њиховим краљевским пријатељем Каспијаном и мишом ратником по имену Рипичип, бивају увучени у једну слику и на величанствен краљевски брод, Намерник зоре.",
+          "runtime": 0,
+          "tagline": "",
+          "title": "Летописи Нарније: Путовање намерника зоре"
+        }
+      },
+      {
+        "iso_3166_1": "VN",
+        "iso_639_1": "vi",
+        "name": "Tiếng Việt",
+        "english_name": "Vietnamese",
+        "data": {
+          "homepage": "",
+          "overview": "Số phận của The Chronicles of Narnia phiên bản điện ảnh cũng long đong, ly kỳ không kém gì cuộc phiêu lưu tại vùng đất huyền bí Narnia của bốn anh em nhà Pevensie. Sau khi thực hiện hai phần đầu (The Lion, the Witch and the Wardrobe và Prince Caspian), hãng Walt Disney bỗng nhiên từ bỏ đứa con cưng của mình. Dự án chuyển thể bộ tiểu thuyết thần thoại nổi tiếng của nhà văn C.S Lewis được “chuyển giao” cho hãng 20th Century Fox. The Voyage of the Dawn Treader (Hành trình trên tàu Dawn Treader) là tập thứ 3 trong Biên niên sử Narnia được dựng thành phim và cũng là tập đầu tiên do hãng 20th Century Fox (đồng) sản xuất và phát hành. Số phận của series The Chronicles of Narnia cũng phụ thuộc rất nhiều vào doanh thu phòng vé của The Voyage of the Dawn Treader. Nếu ăn khách, ...",
+          "runtime": 0,
+          "tagline": "Trở về với phép thuật. Trở về với hy vọng. Trở về với Narnia.",
+          "title": "Biên Niên Sử Narnia: Hành Trình Trên Tàu Dawn Treader"
+        }
+      },
+      {
+        "iso_3166_1": "LT",
+        "iso_639_1": "lt",
+        "name": "Lietuvių",
+        "english_name": "Lithuanian",
+        "data": {
+          "homepage": "",
+          "overview": "Trečiojoje sagos dalyje jau gerai pažįstami vaikai Liusė ir Edmundas vėl sugrįžta į Narniją, lydimi savo pusbrolio. Šįkart į stebuklingąją šalį vaikai patenka pro paveikslą. Ten prie jų prisijungia iš antrojo filmo pažįstamas princas Kaspijanas ir dar vienas žavus veikėjas – kovinė pelė Ripičypas.  Stebuklingu karališkuoju laivu „Aušros užkariautojas“ kompanija nukeliauja į Nuošaliąsias Salas, kuriose jų laukia slapta misija. Šioje kelionėje vaikai patirs daugybę nuotykių bei išmėginimų protui ir širdžiai. Stos akis į akį su daugybe įstabiausių ir ne visuomet geranoriškai nusiteikusių būtybių; turės pasitelkti visą savo drąsą, išmintį ir meilę, kad ir vėl išgelbėtų stebuklingąją liūto Aslano valdomą Narniją ir visus šalies gyventojus.",
+          "runtime": 0,
+          "tagline": "",
+          "title": "Narnijos kronikos: „Aušros užkariautojo“ kelionė"
+        }
+      },
+      {
+        "iso_3166_1": "SA",
+        "iso_639_1": "ar",
+        "name": "العربية",
+        "english_name": "Arabic",
+        "data": {
+          "homepage": "",
+          "overview": "تنتقل (لوسي) وشقيقها (إدموند) إلى عالم (نارنيا) الساحر بصحبة ابن عمهما (إيوستاس)، هذه المرة يتم الانتقال عن طريق لوحة جدارية لسفينة عظيمة تمخر عباب البحر. يفاجأ الأبطال أن الماء يندفع من اللوحة ويغرق الغرفة، وحين تمتلئ عن آخرها يكتشف الأبطال الثلاثة أنهم انتقلوا إلى عالم نارنيا، فى وسط المحيط.",
+          "runtime": 0,
+          "tagline": "",
+          "title": "سجلات نارنيا: رحلة سفينة داون تريدر"
+        }
+      },
+      {
+        "iso_3166_1": "IR",
+        "iso_639_1": "fa",
+        "name": "فارسی",
+        "english_name": "Persian",
+        "data": {
+          "homepage": "",
+          "overview": "",
+          "runtime": 0,
+          "tagline": "",
+          "title": "سرگذشت نارنیا: سفر کشتی سپیده‌پیما"
+        }
+      },
+      {
+        "iso_3166_1": "GE",
+        "iso_639_1": "ka",
+        "name": "ქართული",
+        "english_name": "Georgian",
+        "data": {
+          "homepage": "",
+          "overview": "",
+          "runtime": 0,
+          "tagline": "",
+          "title": "ნარნიის ქრონიკები: განთიადის დამმორჩილებლის მოგზაურობა"
+        }
+      },
+      {
+        "iso_3166_1": "HR",
+        "iso_639_1": "hr",
+        "name": "Hrvatski",
+        "english_name": "Croatian",
+        "data": {
+          "homepage": "",
+          "overview": "U novoj pustolovini koja se odvija u fantastičnoj zemlji Narniji Lucy i Edmund Pevensie te njhov rođak Eustace Scrubb, bivaju uvučeni u sliku, u narnijski brod koji plovi prema rubu svijeta. Lucy i Edmund ponovo se udružuju se sa svojim prijateljem, kraljevićem Kaspijanom, i mišem-ratnikom Reepicheepom i kreću u tajanstvenu misiju do otočja Lone, a i dalje… Na mističnom putovanju bit će stavljeni na kušnju, susrest će opake trgovce robljem, zmajeve koji rigaju vatru, začarane morske ljude… Jedino putovanje u Aslanovu neistraženu zemlju, sudbonosno putovanje koje će promijeniti sve putnike na brodu Zorogaz, može spasiti Narniju njene tajnovite sudbine.",
+          "runtime": 0,
+          "tagline": "Povratak magiji. Povratak nadi. Povratak u Narniju.",
+          "title": "Kronike iz Narnije: Plovidba broda Zorogaza"
+        }
+      },
+      {
+        "iso_3166_1": "SI",
+        "iso_639_1": "sl",
+        "name": "Slovenščina",
+        "english_name": "Slovenian",
+        "data": {
+          "homepage": "",
+          "overview": "Po dveh nepozabnih dogodivščinah se Lucija in Edmund Pevensie znova vrneta v čarobno Narnijo in s seboj pripeljeta nadležnega bratranca Evstahija. Pridružijo se princu Kaspijanu, ki s kraljevo ladjo Potepuška zarja pluje na rob sveta, da bi rešil magično domovino pred grozečim propadom. Na poti se morajo spopasti s temačnimi trgovci s sužnji, čarobnimi škrati, divjimi zmaji in uročenimi bitji iz morskih globin, cilj pa lahko dosežejo le tisti, ki premorejo največ poguma, premetenosti in srčnosti.",
+          "runtime": 0,
+          "tagline": "Potovanje. Pustolovščina.",
+          "title": "Zgodbe iz Narnije: Potovanje Potepuške zarje"
+        }
+      },
+      {
+        "iso_3166_1": "IS",
+        "iso_639_1": "is",
+        "name": "Íslenska",
+        "english_name": "Icelandic",
+        "data": {
+          "homepage": "",
+          "overview": "",
+          "runtime": 0,
+          "tagline": "",
+          "title": "Ævintýralandið Narnía: Sigling Dagfara"
+        }
+      },
+      {
+        "iso_3166_1": "AT",
+        "iso_639_1": "de",
+        "name": "Deutsch",
+        "english_name": "German",
+        "data": {
+          "homepage": "",
+          "overview": "",
+          "runtime": 0,
+          "tagline": "",
+          "title": ""
+        }
+      }
+    ]
   }
 }

--- a/tmdb-api/src/jvmTest/resources/tmdb3/person/person_details_11701_all_responses.json
+++ b/tmdb-api/src/jvmTest/resources/tmdb3/person/person_details_11701_all_responses.json
@@ -6355,7 +6355,9 @@
                 "name": "English",
                 "english_name": "English",
                 "data": {
-                    "biography": "Angelina Jolie is an American actress. She has received an Academy Award, two Screen Actors Guild Awards, and three Golden Globe Awards. Jolie has promoted humanitarian causes throughout the world, and is noted for her work with refugees as a Goodwill Ambassador for the United Nations High Commissioner for Refugees (UNHCR). She has been cited as one of the world's most beautiful women and her off-screen life is widely reported.\n\nThough she made her screen debut as a child alongside her father Jon Voight in the 1982 film Lookin' to Get Out, Jolie's acting career began in earnest a decade later with the low-budget production Cyborg 2 (1993). Her first leading role in a major film was in Hackers (1995). She starred in the critically acclaimed biographical films George Wallace (1997) and Gia (1998), and won an Academy Award for Best Supporting Actress for her performance in the drama Girl, Interrupted (1999). Jolie achieved wider fame after her portrayal of video game heroine Lara Croft in Lara Croft: Tomb Raider (2001), and since then has established herself as one of the best-known and highest-paid actresses in Hollywood. She has had her biggest commercial successes with the action-comedy Mr. & Mrs. Smith (2005) and the animated film Kung Fu Panda (2008).\n\nDivorced from actors Jonny Lee Miller and Billy Bob Thornton, Jolie currently lives with actor Brad Pitt, in a relationship that has attracted worldwide media attention. Jolie and Pitt have three adopted children, Maddox, Pax, and Zahara, as well as three biological children, Shiloh, Knox, and Vivienne."
+                    "biography": "Angelina Jolie (/dʒoʊˈliː/ joh-LEE; born Angelina Jolie Voight, /ˈvɔɪt/, June 4, 1975) is an American actress, filmmaker, and humanitarian. The recipient of numerous accolades, including an Academy Award, a Tony Award and three Golden Globe Awards, she has been named Hollywood's highest-paid actress multiple times.\n\nJolie made her screen debut as a child alongside her father, Jon Voight, in Lookin' to Get Out (1982). Her film career began in earnest a decade later with the low-budget production Cyborg 2 (1993), followed by her first leading role in Hackers (1995). After starring in the television films George Wallace (1997) and Gia (1998), Jolie won the Academy Award for Best Supporting Actress for the 1999 drama Girl, Interrupted. Her portrayal of the titular heroine in Lara Croft: Tomb Raider (2001) established her as a leading lady. Jolie's success continued with roles in the action films Mr. & Mrs. Smith (2005), Wanted (2008), and Salt (2010), as well as in the fantasy film Maleficent (2014) and its 2019 sequel. She also had voice roles in the animated films Shark Tale (2004) and the Kung Fu Panda franchise (2008–2016). She gained praise for her dramatic performances in A Mighty Heart (2007), Changeling (2008), which earned her a nomination for the Academy Award for Best Actress, and Maria (2024). \n\nAs a filmmaker, Jolie directed and wrote the war dramas In the Land of Blood and Honey (2011), Unbroken (2014), First They Killed My Father (2017) and Without Blood (2024). She also produced the musical The Outsiders (2024), winning the Tony Award for Best Musical.\n\nJolie is known for her humanitarian efforts. The causes she promotes include conservation, education, and women's rights. She has been noted for her advocacy on behalf of refugees as a Special Envoy for the United Nations High Commissioner for Refugees. She has undertaken field missions to refugee camps and war zones worldwide. In addition to receiving a Jean Hersholt Humanitarian Award among other honours, Jolie was made an honorary Dame Commander of the Order of St Michael and St George. As a public figure, Jolie has been cited as one of the most powerful and influential people in the American entertainment industry. She has been cited as the world's most beautiful woman by various publications. Her personal life, including her relationships and health, has been the subject of widespread attention. Jolie is divorced from actors Jonny Lee Miller, Billy Bob Thornton, and Brad Pitt. She has six children with Pitt.\n\nDescription above from the Wikipedia article Angelina Jolie, licensed under CC-BY-SA, full list of contributors on Wikipedia.",
+                    "name": "Angelina Jolie",
+                    "primary": true
                 }
             },
             {
@@ -6364,7 +6366,9 @@
                 "name": "Português",
                 "english_name": "Portuguese",
                 "data": {
-                    "biography": "Angelina Jolie Pitt (née Voight, Los Angeles, 4 de junho de 1975) é uma atriz, dubladora, diretora, produtora, roteirista e ativista humanitária americana. Vencedora de um Óscar (2000), dois Prémios Screen Actors Guild (1998 e 1999), e três Prêmios Globo de Ouro (1997, 1998 e 1999). Trabalha com assuntos humanitários desde 2000, quando filmou Lara Croft: Tomb Raider no Camboja. Em 27 de agosto de 2001, foi nomeada Embaixadora da Boa Vontade do ACNUR. Em 17 de abril de 2012, foi nomeada Enviada Especial do ACNUR. Tem sido frequentemente citada como a mulher \"mais bonita\" ou \"mais sexy\" do mundo."
+                    "biography": "Angelina Jolie Pitt (née Voight, Los Angeles, 4 de junho de 1975) é uma atriz, dubladora, diretora, produtora, roteirista e ativista humanitária americana. Vencedora de um Óscar (2000), dois Prémios Screen Actors Guild (1998 e 1999), e três Prêmios Globo de Ouro (1997, 1998 e 1999). Trabalha com assuntos humanitários desde 2000, quando filmou Lara Croft: Tomb Raider no Camboja. Em 27 de agosto de 2001, foi nomeada Embaixadora da Boa Vontade do ACNUR. Em 17 de abril de 2012, foi nomeada Enviada Especial do ACNUR. Tem sido frequentemente citada como a mulher \"mais bonita\" ou \"mais sexy\" do mundo.",
+                    "name": "",
+                    "primary": false
                 }
             },
             {
@@ -6373,7 +6377,9 @@
                 "name": "Español",
                 "english_name": "Spanish",
                 "data": {
-                    "biography": "Angelina Jolie Voight es una actriz, modelo, filántropa, actriz de voz, directora, guionista y activista por los derechos de las mujeres estadounidenses que también posee la nacionalidad camboyana. A lo largo de su carrera, Jolie ha recibido varios reconocimientos por sus logros actorales, entre ellos dos Premios Óscar (uno a mejor actriz y el premio humanitario) y tres Globos de Oro. Desde 2012 es Enviada Especial del Alto Comisionado de las Naciones Unidas para los Refugiados. En 2016 la London School of Economics anunció que Jolie sería profesora de un nuevo tipo de máster sobre «Las mujeres, la paz y la seguridad» con el objetivo de promover la igualdad de sexos y ayudar a las mujeres afectadas por los conflictos de todo el mundo."
+                    "biography": "Angelina Jolie Voight es una actriz, modelo, filántropa, actriz de voz, directora, guionista y activista por los derechos de las mujeres estadounidenses que también posee la nacionalidad camboyana. A lo largo de su carrera, Jolie ha recibido varios reconocimientos por sus logros actorales, entre ellos dos Premios Óscar (uno a mejor actriz y el premio humanitario) y tres Globos de Oro. Desde 2012 es Enviada Especial del Alto Comisionado de las Naciones Unidas para los Refugiados. En 2016 la London School of Economics anunció que Jolie sería profesora de un nuevo tipo de máster sobre «Las mujeres, la paz y la seguridad» con el objetivo de promover la igualdad de sexos y ayudar a las mujeres afectadas por los conflictos de todo el mundo.",
+                    "name": "",
+                    "primary": false
                 }
             },
             {
@@ -6382,7 +6388,9 @@
                 "name": "Slovenčina",
                 "english_name": "Slovak",
                 "data": {
-                    "biography": "Kurzy herectva navštevovala od 11-tich rokov. V 13-tich rokoch mala prvé tetovanie.  V 16-tich rokoch sa dostala k práci ako modelka v Londýne, Los Angeles a New Yorku. Angelina dokazovala, že nepotrebuje meno slávneho otca, aby sa presadila. Nastáva komerčné obdobie jej života, čo potvrdzuje aj ponuka od režiséra Simon Westa na sfilmovanie akčnej postavy Lary Croft z počítačovej hry Tomb Rider.\n\nHra bola hitom po celom svete a hlavne preto mala filmová verzia veľký potenciál. Lara Croft: Tomb Rider z roku 2001 sa stal úspešný film, ktorý pri rozpočte 80 mil. dolárov zarobil len v amerických kinách 130 mil. dolárov. Pokračovanie na seba nedalo dlho čakať a do kín v roku 2003 prišla Lara Croft-Tomb Rider: The Cradle of Life (kolíska života). Druhý diel nebol taký úspešný ako prvý, najmä u kritikov.\n\nRok 2004, je rok od rozvodu z Billym Bobom Thortonom. Jediné, čo Angie po ňom zostalo bolo nahlodané sebavedomie a tetovanie. Začína sa stále viac zaujímať o humanitárne práce. Adoptovala si kambodžského chlapca menom Maddox a aj to bol možno dôvod rozvodu s Billym.\n\nNeprejde ani chvíľa od posledného filmu a Angelina sa púšťa do zaujímavej postavy, kde stvárni matku macedónskeho dobyvateľa Alexandra Veľkého v podaní Colina Farrella. Ani veľkolepá výprava, fantastický režisér, výborní herci nezabránili prepadnutiu filmu tak u kritikov ako ja u divákov. Ďalšou historickou drámou je Love and Honor, v ktorej stvárnila cárovnú Katarínu Veľkú.\n\nČasopis People ju zaradil medzi 50 najkrajších ľudí sveta, kráľ Kambodže jej udelil národné občianstvo a nazývajú ju veľvyslankyňa dobrej vôle UNHCR. Je rada, že si to ľudia o nej myslia. Film Beyond Borders bol takou malou kampaňou na pomoc krajinám tretieho sveta. Medzi jej posledné úlohy patrí postava manželky zavraždeného novinára Daniela Pearla vo filme A Mighty Heart. Angelina vstupuje do digitálneho veku.\n\nV súčasnosti žije s hercom Bradom Pittom, s ktorým má tri biologické deti: Shiloh, Knox a Vivienne. Spolu adoptovali deti Maddoxa, Zaharu a Paxa. Angelina Jolie sa angažuje v humanitárnych projektoch na celom svete, hlavne týkajúcich sa problematiky utečencov v rámci UNHCR.\n\n13. júna 2014 jej anglická kráľovná Alžbeta II. udelila čestný rad Dame za prácu v boji proti sexuálnemu násiliu vo vojnových zónach."
+                    "biography": "Kurzy herectva navštevovala od 11-tich rokov. V 13-tich rokoch mala prvé tetovanie.  V 16-tich rokoch sa dostala k práci ako modelka v Londýne, Los Angeles a New Yorku. Angelina dokazovala, že nepotrebuje meno slávneho otca, aby sa presadila. Nastáva komerčné obdobie jej života, čo potvrdzuje aj ponuka od režiséra Simon Westa na sfilmovanie akčnej postavy Lary Croft z počítačovej hry Tomb Rider.\n\nHra bola hitom po celom svete a hlavne preto mala filmová verzia veľký potenciál. Lara Croft: Tomb Rider z roku 2001 sa stal úspešný film, ktorý pri rozpočte 80 mil. dolárov zarobil len v amerických kinách 130 mil. dolárov. Pokračovanie na seba nedalo dlho čakať a do kín v roku 2003 prišla Lara Croft-Tomb Rider: The Cradle of Life (kolíska života). Druhý diel nebol taký úspešný ako prvý, najmä u kritikov.\n\nRok 2004, je rok od rozvodu z Billym Bobom Thortonom. Jediné, čo Angie po ňom zostalo bolo nahlodané sebavedomie a tetovanie. Začína sa stále viac zaujímať o humanitárne práce. Adoptovala si kambodžského chlapca menom Maddox a aj to bol možno dôvod rozvodu s Billym.\n\nNeprejde ani chvíľa od posledného filmu a Angelina sa púšťa do zaujímavej postavy, kde stvárni matku macedónskeho dobyvateľa Alexandra Veľkého v podaní Colina Farrella. Ani veľkolepá výprava, fantastický režisér, výborní herci nezabránili prepadnutiu filmu tak u kritikov ako ja u divákov. Ďalšou historickou drámou je Love and Honor, v ktorej stvárnila cárovnú Katarínu Veľkú.\n\nČasopis People ju zaradil medzi 50 najkrajších ľudí sveta, kráľ Kambodže jej udelil národné občianstvo a nazývajú ju veľvyslankyňa dobrej vôle UNHCR. Je rada, že si to ľudia o nej myslia. Film Beyond Borders bol takou malou kampaňou na pomoc krajinám tretieho sveta. Medzi jej posledné úlohy patrí postava manželky zavraždeného novinára Daniela Pearla vo filme A Mighty Heart. Angelina vstupuje do digitálneho veku.\n\nV súčasnosti žije s hercom Bradom Pittom, s ktorým má tri biologické deti: Shiloh, Knox a Vivienne. Spolu adoptovali deti Maddoxa, Zaharu a Paxa. Angelina Jolie sa angažuje v humanitárnych projektoch na celom svete, hlavne týkajúcich sa problematiky utečencov v rámci UNHCR.\n\n13. júna 2014 jej anglická kráľovná Alžbeta II. udelila čestný rad Dame za prácu v boji proti sexuálnemu násiliu vo vojnových zónach.",
+                    "name": "",
+                    "primary": false
                 }
             },
             {
@@ -6391,7 +6399,9 @@
                 "name": "Український",
                 "english_name": "Ukrainian",
                 "data": {
-                    "biography": "Анджеліна Джолі Пітт (англ. Angelina Jolie Pitt; нар. 4 червня 1975, Лос-Анджелес США) — американська акторка, фотомодель, режисер, посол доброї волі ООН, лауреат премії «Оскар» та трьох премій «Золотий глобус».\n\nДебютувала в кіно у 1982 році, зігравши роль у фільмі У пошуках виходу. Однак стала відомою після того, як зіграла Лару Крофт у фільмах Лара Крофт: Розкрадачка гробниць (2001) та Лара Крофт розкрадачка гробниць: колиска життя (2003). Серед інших відомих її ролей — Містер і місіс Сміт (2005), Особливо небезпечний (2008) та Солт (2010).\n\nУ 2009, 2011 та 2013 роках, згідно із версією журналу Forbes, Джолі була визнана найвисокооплачуванішою акторкою Голлівуду."
+                    "biography": "Анджеліна Джолі — американська акторка, фотомодель, режисерка, посол доброї волі ООН, лауреатка премії «Оскар» і трьох премій «Золотий глобус».\n\nДебютувала в кіно 1982 року, зігравши у фільмі «У пошуках виходу». Проте стала відомою після ролі Лари Крофт у фільмах «Лара Крофт: Розкрадачка гробниць» (2001) і «Лара Крофт: Розкрадачка гробниць. Колиска життя» (2003). Серед інших відомих її фільмів — «Містер і місіс Сміт» (2005), «Особливо небезпечний» (2008) і «Солт» (2010).\n\nУ 2009, 2011 та 2013 роках, згідно з версією журналу Forbes, Джолі була визнана найвисокооплачуванішою акторкою Голлівуду.",
+                    "name": "Анджеліна Джолі",
+                    "primary": false
                 }
             },
             {
@@ -6400,7 +6410,9 @@
                 "name": "Pусский",
                 "english_name": "Russian",
                 "data": {
-                    "biography": "Американская актриса, кинорежиссёр и сценарист, фотомодель, посол доброй воли ООН.\n\nОбладательница премии «Оскар», трёх премий «Золотой глобус» (первая актриса в истории, три года подряд выигравшая премию) и двух «Премий Гильдии киноактёров США».\n\nДебютировала в кино в 1982 году, сыграв роль в комедийном фильме «В поисках выхода» (где снимались также её отец и мать), однако известность получила после того, как сыграла героиню видеоигр Лару Крофт в фильмах «Лара Крофт: Расхитительница гробниц» и «Лара Крофт: Расхитительница гробниц. Колыбель жизни».\n\nВ 2009, 2011 и 2013 годах по версии журнала Forbes Джоли была названа самой высокооплачиваемой актрисой Голливуда.\n\nЕё наиболее успешными с коммерческой стороны фильмами стали «Малефисента» (сборы в мировом прокате — 758 миллионов долларов США), «Мистер и миссис Смит» (сборы в мировом прокате — 478 миллионов долларов США), «Особо опасен» (341 миллион долларов США), «Солт» (293 миллиона долларов США), а также «Турист» (278 миллионов долларов США), «Лара Крофт: Расхитительница гробниц» (274 миллиона долларов США) и картина с участием Николаса Кейджа «Угнать за 60 секунд» (237 миллионов долларов США)"
+                    "biography": "💥Анджелина Джоли Войт. Родилась в 1975-ом году в Лос-Анджелесе, Калифорния, США. Росла в семье со старшим братом. Отец работал актёром, а мать была продюсером. Училась в актёрской студии Ли Страсберга в Нью-Йорке. Работает актрисой, режиссёром и послом доброй воли ООН. Трижды замужем: за Джонни Ли Миллером, за Билли Бобом Торнтоном и за Брэдом Питтом, у пары 6-ро детей: 3-ое биологических (сын Нокс, дочери Шайло и Вивьен) и 3-ое приёмных (сыновья Мэддокс и Пакс, дочь Захара). Свою текущую личную жизнь предпочитает держать в тайне\n\n🏆Главные награды🏆: Оскар (2000) [Прерванная жизнь], Золотой глобус (1999) [Джиа], Золотой глобус (2000) [Прерванная жизнь], Critics’ Choice Awards (2000) [Прерванная жизнь]\n\n🎬Главные проекты🎬: «Соблазн» (2001), «Мистер и миссис Смит» (2005), «Малефисента» (2014), «Лара Крофт: Расхитительница гробниц» (2001), «Мария» (2024), «Прерванная жизнь» (1999), «Джиа» (1998)\n\n⭐Интересный факт⭐: Анджелина одна из самых известных гуманитарных активисток мира, она посетила более 60 стран в рамках миссий ООН, помогая беженцам и открыла несколько благотворительных фондов. Анджелина взяла своё 2-ое имя \"Джоли\", как фамилию вместо \"Войт\"",
+                    "name": "Анджелина Джоли",
+                    "primary": false
                 }
             },
             {
@@ -6409,7 +6421,9 @@
                 "name": "ქართული",
                 "english_name": "Georgian",
                 "data": {
-                    "biography": "ანჯელინა ჯოლი ამერიკელი მსახიობია. მან მიიღო აკადემიის ჯილდო, ორი კინომსახიობთა გილდიის ჯილდო და სამი ოქროს გლობუსის ჯილდო. ჯოლი ჰუმანიტარული მიზეზების მთელ მსოფლიოში ხელს უწყობს და აღნიშნა, რომ ლტოლვილებთან მუშაობისას გაეროს ლტოლვილთა უმაღლეს კომისარს (UNHCR) კეთილი ნების ელჩი გახლდათ. იგი მოიხსენიება მსოფლიოს ერთ-ერთ ულამაზეს ქალბატონად და მისი ეკრანის ცხოვრება ფართოდ გავრცელებულია. მიუხედავად იმისა, რომ მან თავისი ფილმის დებიუტი გახადა, როგორც მამამისი ჯონ ვოიტი, 1982 წელს ფილმის \"გამოსვლა\", ჯოლის მოვალეობის შემსრულებელი კარიერა დაიწყო ათწლეულის მოგვიანებით დაბალ ბიუჯეტიან Cyborg 2 (1993). მისი პირველი წამყვანი როლი ძირითადი ფილმი იყო ჰაკერსი (1995). მან ითამაშა კრიტიკულად აღიარებულ ბიოგრაფიულ ფილმებში ჯორჯ უოლესი (1997) და გია (1998) და მოიპოვა საუკეთესო კინომსახიობისთვის აკადემიის ჯილდო, მისი სპექტაკლისთვის. ჯოლიმ მოიპოვა ლაირო კროფტის (Tara Raider) (2001) ფილმში \"Lara Croft\" - ის ვიდეო თამაშის ჰეროინი, რომელიც მას ჰოლივუდში ერთ-ერთი ყველაზე ცნობილი და ყველაზე მაღალანაზღაურებადი მსახიობია. მას ჰქონდა ყველაზე დიდი კომერციული წარმატება სამოქმედო კომედია ბატონი & ქალბატონი სმიტი (2005) და ანიმაციური ფილმი Kung Fu Panda (2008). ჯოლისა და ბილი ბობ თორნტონის მსახიობებიდან გატაცებული ჯოლი ამჟამად ცხოვრობს მსახიობ ბრედ პიტისთან, ურთიერთობებში, რომელიც მიიპყრო მსოფლიო მედიის ყურადღებას. ჯოლი და პიტი სამი შვილიშვილი, მადაქსი, პაქსი და ზაჰარა, ასევე ბიოლოგიური შვილები, შილო, ნოქსი და ვივინენი."
+                    "biography": "ანჯელინა ჯოლი ამერიკელი მსახიობია. მან მიიღო აკადემიის ჯილდო, ორი კინომსახიობთა გილდიის ჯილდო და სამი ოქროს გლობუსის ჯილდო. ჯოლი ჰუმანიტარული მიზეზების მთელ მსოფლიოში ხელს უწყობს და აღნიშნა, რომ ლტოლვილებთან მუშაობისას გაეროს ლტოლვილთა უმაღლეს კომისარს (UNHCR) კეთილი ნების ელჩი გახლდათ. იგი მოიხსენიება მსოფლიოს ერთ-ერთ ულამაზეს ქალბატონად და მისი ეკრანის ცხოვრება ფართოდ გავრცელებულია. მიუხედავად იმისა, რომ მან თავისი ფილმის დებიუტი გახადა, როგორც მამამისი ჯონ ვოიტი, 1982 წელს ფილმის \"გამოსვლა\", ჯოლის მოვალეობის შემსრულებელი კარიერა დაიწყო ათწლეულის მოგვიანებით დაბალ ბიუჯეტიან Cyborg 2 (1993). მისი პირველი წამყვანი როლი ძირითადი ფილმი იყო ჰაკერსი (1995). მან ითამაშა კრიტიკულად აღიარებულ ბიოგრაფიულ ფილმებში ჯორჯ უოლესი (1997) და გია (1998) და მოიპოვა საუკეთესო კინომსახიობისთვის აკადემიის ჯილდო, მისი სპექტაკლისთვის. ჯოლიმ მოიპოვა ლაირო კროფტის (Tara Raider) (2001) ფილმში \"Lara Croft\" - ის ვიდეო თამაშის ჰეროინი, რომელიც მას ჰოლივუდში ერთ-ერთი ყველაზე ცნობილი და ყველაზე მაღალანაზღაურებადი მსახიობია. მას ჰქონდა ყველაზე დიდი კომერციული წარმატება სამოქმედო კომედია ბატონი & ქალბატონი სმიტი (2005) და ანიმაციური ფილმი Kung Fu Panda (2008). ჯოლისა და ბილი ბობ თორნტონის მსახიობებიდან გატაცებული ჯოლი ამჟამად ცხოვრობს მსახიობ ბრედ პიტისთან, ურთიერთობებში, რომელიც მიიპყრო მსოფლიო მედიის ყურადღებას. ჯოლი და პიტი სამი შვილიშვილი, მადაქსი, პაქსი და ზაჰარა, ასევე ბიოლოგიური შვილები, შილო, ნოქსი და ვივინენი.",
+                    "name": "ანჯელინა ჯოლი",
+                    "primary": false
                 }
             },
             {
@@ -6418,7 +6432,9 @@
                 "name": "ελληνικά",
                 "english_name": "Greek",
                 "data": {
-                    "biography": "Η Αντζελίνα Τζολί είναι Αμερικανίδα ηθοποιός, σκηνοθέτρια και ειδική απεσταλμένη του ΟΗΕ για τους πρόσφυγες."
+                    "biography": "Η Αντζελίνα Τζολί είναι Αμερικανίδα ηθοποιός, σκηνοθέτρια και ειδική απεσταλμένη του ΟΗΕ για τους πρόσφυγες.",
+                    "name": "Αντζελίνα Τζολί",
+                    "primary": false
                 }
             },
             {
@@ -6427,7 +6443,9 @@
                 "name": "Magyar",
                 "english_name": "Hungarian",
                 "data": {
-                    "biography": "Angelina Jolie Pitt Los Angelesben született 1975. június 4-én. Amerikai színésznő, rendező, és a humanitárius. Eddigi legnagyobb díjai közé tartozik az Oscar-díj, a két Screen Actors Guild Awards-díj, és három Golden Globe-díj, így nem véletlenül vált Hollywood egyik legjobban fizetett színésznőjévé. Először csak videóklipekben szerepelt, majd filmes karrierbe kezdett a George Wallace című filmmel (1997), amiért Golden Globe és Emmy-díjra is jelölték.\n\nEzt követően olyan filmekben játszott, mint az Észvesztő (2000) és a Vakrepülés (1999), amiért újabb Golden Globe díjat kapott. Ekkor házasodott össze Billy Bob Thortonnal.\n\nAz igazi áttörést azonban egy videojáték-adaptáció, a Lara Croft: Tomb Raider (2001) című film hozta meg számára, mely ugyan nem aratott sikert szakmai körökben, a mozipénztáraknál kimondottan jól szerepelt. A kambodzsai forgatás során vált elkötelezetté a humanitárius ügyek iránt, később így lett az ENSZ nagykövete. Jelenlegi férjével, Brad Pitt-tel való kapcsolata állítólag a Mr. és Mrs. Smith (2005) című kémfilm forgatásán kezdődött, Pitt mindenesetre még abban az évben elvált korábbi feleségétől, Jennifer Anistontól.\n\nJolie rendezőként is bizonyított, először 2011-ben a bosnyák-szerb háborút feldolgozó A vér és méz földje című filmmel.\n\nLegutóbb a filmvásznon a Demóna (2014) című Disney-szuperprodukcióban láthattuk. Brad Pitt-el 2014-ben házasodtak össze, de házasságuk 2016-ban hivatalosan is véget ért."
+                    "biography": "Angelina Jolie Pitt Los Angelesben született 1975. június 4-én. Amerikai színésznő, rendező, és a humanitárius. Eddigi legnagyobb díjai közé tartozik az Oscar-díj, a két Screen Actors Guild Awards-díj, és három Golden Globe-díj, így nem véletlenül vált Hollywood egyik legjobban fizetett színésznőjévé. Először csak videóklipekben szerepelt, majd filmes karrierbe kezdett a George Wallace című filmmel (1997), amiért Golden Globe és Emmy-díjra is jelölték.\n\nEzt követően olyan filmekben játszott, mint az Észvesztő (2000) és a Vakrepülés (1999), amiért újabb Golden Globe díjat kapott. Ekkor házasodott össze Billy Bob Thortonnal.\n\nAz igazi áttörést azonban egy videojáték-adaptáció, a Lara Croft: Tomb Raider (2001) című film hozta meg számára, mely ugyan nem aratott sikert szakmai körökben, a mozipénztáraknál kimondottan jól szerepelt. A kambodzsai forgatás során vált elkötelezetté a humanitárius ügyek iránt, később így lett az ENSZ nagykövete. Jelenlegi férjével, Brad Pitt-tel való kapcsolata állítólag a Mr. és Mrs. Smith (2005) című kémfilm forgatásán kezdődött, Pitt mindenesetre még abban az évben elvált korábbi feleségétől, Jennifer Anistontól.\n\nJolie rendezőként is bizonyított, először 2011-ben a bosnyák-szerb háborút feldolgozó A vér és méz földje című filmmel.\n\nLegutóbb a filmvásznon a Demóna (2014) című Disney-szuperprodukcióban láthattuk. Brad Pitt-el 2014-ben házasodtak össze, de házasságuk 2016-ban hivatalosan is véget ért.",
+                    "name": "",
+                    "primary": false
                 }
             },
             {
@@ -6436,7 +6454,9 @@
                 "name": "Deutsch",
                 "english_name": "German",
                 "data": {
-                    "biography": "Sie wurde mit der Darstellung der Videospielheldin Lara Croft in Lara Croft: Tomb Raider (2001) international bekannt. Weitere kommerzielle Erfolge hatte sie mit den Filmen Mr. & Mrs. Smith (2005), Wanted (2008), Salt (2010) und Maleficent – Die dunkle Fee (2014). Für ihre schauspielerischen Leistungen erhielt Jolie drei Golden Globes, zwei Screen Actors Guild Awards und für ihre Rolle einer psychisch Kranken in dem Film Durchgeknallt (1999) einen Oscar als beste Nebendarstellerin. Mit dem Kriegsdrama In the Land of Blood and Honey gab Jolie 2011 ihr Debüt als Spielfilmregisseurin und Drehbuchautorin.\n\nSie ist zudem Sondergesandte des UN-Flüchtlingshochkommissars Filippo Grandi, Mitglied des Council on Foreign Relations und war Sonderbotschafterin für das UNO-Hochkommissariat für Flüchtlinge."
+                    "biography": "Sie wurde mit der Darstellung der Videospielheldin Lara Croft in Lara Croft: Tomb Raider (2001) international bekannt. Weitere kommerzielle Erfolge hatte sie mit den Filmen Mr. & Mrs. Smith (2005), Wanted (2008), Salt (2010) und Maleficent – Die dunkle Fee (2014). Für ihre schauspielerischen Leistungen erhielt Jolie drei Golden Globes, zwei Screen Actors Guild Awards und für ihre Rolle einer psychisch Kranken in dem Film Durchgeknallt (1999) einen Oscar als beste Nebendarstellerin. Mit dem Kriegsdrama In the Land of Blood and Honey gab Jolie 2011 ihr Debüt als Spielfilmregisseurin und Drehbuchautorin.\n\nSie ist zudem Sondergesandte des UN-Flüchtlingshochkommissars Filippo Grandi, Mitglied des Council on Foreign Relations und war Sonderbotschafterin für das UNO-Hochkommissariat für Flüchtlinge.",
+                    "name": "",
+                    "primary": false
                 }
             },
             {
@@ -6445,7 +6465,9 @@
                 "name": "한국어/조선말",
                 "english_name": "Korean",
                 "data": {
-                    "biography": ""
+                    "biography": "",
+                    "name": "안젤리나 졸리",
+                    "primary": false
                 }
             },
             {
@@ -6454,7 +6476,9 @@
                 "name": "普通话",
                 "english_name": "Mandarin",
                 "data": {
-                    "biography": "安潔莉娜裘莉的父親是奧斯卡影帝強沃特，但很小的時候父母就離異，因此與父親關係長期不和，甚至與父親斷絕父女關係，和母親同住。由於從小生活在好萊塢，安潔莉娜很早就和演藝圈有所接觸，七歲時就成為童星，也曾經擔任過模特兒。1993年，安潔莉娜進入電影圈，在演了一些反映平淡的影片後，終於在1997年因為在電視電影《風雲傳奇》中一鳴驚人，獲得金球獎電視電影類最佳女配角。緊接著她演出的另一部電視電影《霓裳情挑》又為她再次獲得金球獎，而1999年她在電影《女生向前走》中，飾演一位個性狂野偏執但是內心又相當脆弱的精神病患，精采的演出，獲得該年奧斯卡金像獎最佳女配角獎。年輕的安潔莉娜從此名聲鵲起，成為好萊塢後起之秀中的佼佼者。\n\n2001年的《古墓奇兵》，讓安潔莉娜成為好萊塢首屈一指的動作女星。這段期間安潔莉娜與演員兼導演比利鮑伯松頓閃電結婚，在 2003年5月離婚。2004年，她與布萊德彼特因拍攝《史密斯任務》傳出戀情，展開了至今仍是八卦媒體爭相追逐的「布裘戀」。在持續推出許多賣座動作片後， 2007年，她在一部小成本電影《無畏之心》中，演出一位丈夫遭恐怖份子挾持的女記者，不同於以往的演出，讓安潔莉娜獲得金球獎最佳女主角的提名。2008年她在大導演克林伊斯威特的《陌生的孩子》中飾演一位一心要找回失蹤兒子的單親媽媽，獲得奧斯卡最佳女主角提名。\n\n除了演出多部票房成功的電影外，裘莉也積極投身慈善事業，經常親自深入難民區探望可憐的災名，也領養了多位第三世界國家的孤兒，更獲選為聯合國親善大使。而當她拾起導演筒，也關懷世界其他角落、生活在戰爭中的人們。《愛在血淚交織時》和《他們先殺了我父親：柬埔寨女孩的回憶》都獲得金球獎的最佳外語片獎提名。期間還執導人性黑暗與光輝交相輝映的《永不屈服》。\n\n2006年她與布萊德彼特生下一女，三年後又生下一對龍鳳胎，享受著熱鬧的家庭生活。2009年，安潔莉娜也開始與父親接觸，父女關係得到緩和。2019年，她與布萊德彼特完成離婚手續。戲內她從《亞歷山大帝》的母親、《貝武夫：北海的詛咒》食人魔的母親，到《黑魔女：沉睡魔咒》當起奧蘿拉公主沒有血緣的母親。戲裡戲外一路走來，母親的角色讓她感觸良多。未來將加入漫威宇宙，為觀眾帶來最新的超能力英雄《永恆族》。"
+                    "biography": "安潔莉娜裘莉的父親是奧斯卡影帝強沃特，但很小的時候父母就離異，因此與父親關係長期不和，甚至與父親斷絕父女關係，和母親同住。由於從小生活在好萊塢，安潔莉娜很早就和演藝圈有所接觸，七歲時就成為童星，也曾經擔任過模特兒。1993年，安潔莉娜進入電影圈，在演了一些反映平淡的影片後，終於在1997年因為在電視電影《風雲傳奇》中一鳴驚人，獲得金球獎電視電影類最佳女配角。緊接著她演出的另一部電視電影《霓裳情挑》又為她再次獲得金球獎，而1999年她在電影《女生向前走》中，飾演一位個性狂野偏執但是內心又相當脆弱的精神病患，精采的演出，獲得該年奧斯卡金像獎最佳女配角獎。年輕的安潔莉娜從此名聲鵲起，成為好萊塢後起之秀中的佼佼者。\n\n2001年的《古墓奇兵》，讓安潔莉娜成為好萊塢首屈一指的動作女星。這段期間安潔莉娜與演員兼導演比利鮑伯松頓閃電結婚，在 2003年5月離婚。2004年，她與布萊德彼特因拍攝《史密斯任務》傳出戀情，展開了至今仍是八卦媒體爭相追逐的「布裘戀」。在持續推出許多賣座動作片後， 2007年，她在一部小成本電影《無畏之心》中，演出一位丈夫遭恐怖份子挾持的女記者，不同於以往的演出，讓安潔莉娜獲得金球獎最佳女主角的提名。2008年她在大導演克林伊斯威特的《陌生的孩子》中飾演一位一心要找回失蹤兒子的單親媽媽，獲得奧斯卡最佳女主角提名。\n\n除了演出多部票房成功的電影外，裘莉也積極投身慈善事業，經常親自深入難民區探望可憐的災名，也領養了多位第三世界國家的孤兒，更獲選為聯合國親善大使。而當她拾起導演筒，也關懷世界其他角落、生活在戰爭中的人們。《愛在血淚交織時》和《他們先殺了我父親：柬埔寨女孩的回憶》都獲得金球獎的最佳外語片獎提名。期間還執導人性黑暗與光輝交相輝映的《永不屈服》。\n\n2006年她與布萊德彼特生下一女，三年後又生下一對龍鳳胎，享受著熱鬧的家庭生活。2009年，安潔莉娜也開始與父親接觸，父女關係得到緩和。2019年，她與布萊德彼特完成離婚手續。戲內她從《亞歷山大帝》的母親、《貝武夫：北海的詛咒》食人魔的母親，到《黑魔女：沉睡魔咒》當起奧蘿拉公主沒有血緣的母親。戲裡戲外一路走來，母親的角色讓她感觸良多。未來將加入漫威宇宙，為觀眾帶來最新的超能力英雄《永恆族》。",
+                    "name": "安潔莉娜·裘莉",
+                    "primary": false
                 }
             },
             {
@@ -6463,7 +6487,9 @@
                 "name": "Français",
                 "english_name": "French",
                 "data": {
-                    "biography": "Angelina Jolie est une actrice américaine. Elle a reçu un Academy Award, deux Screen Actors Guild Awards et trois Golden Globe Awards. Angelina Jolie a soutenu des causes humanitaires dans le monde entier et est connue pour son travail avec les réfugiés en tant qu'ambassadrice de la paix du Haut Commissariat des Nations Unies pour les Réfugiés (HCNUR). Elle a été citée comme l'une des plus belles femmes du monde et sa vie hors écran est largement diffusée.\n\nBien qu'elle ait fait ses débuts à l'écran dès son enfance aux côtés de son père Jon Voight dans le film Lookin' to Get Out (1982), la carrière d'actrice d'Angelina Jolie a commencé sérieusement une décennie plus tard avec la production à petit budget Cyborg 2 (1993). Son premier rôle principal dans un grand film a été dans Hackers (1995). Elle a joué dans les films biographiques acclamés par la critique George Wallace (1997) et Gia (1998), et a remporté un Oscar du meilleur second rôle féminin pour sa performance dans le drame Une Vie volée (1999). Elle a atteint une plus grande notoriété après son interprétation de l'héroïne du jeu vidéo Lara Croft dans Lara Croft : Tomb Raider (2001), et s'est depuis établie comme l'une des actrices les plus connues et les mieux payées d'Hollywood. Elle a connu ses plus grands succès commerciaux avec la comédie d'action Mr. & Mrs. Smith (2005) et le film d'animation Kung Fu Panda (2008).\n\nDivorcée des acteurs Jonny Lee Miller et Billy Bob Thornton, Jolie s'est remariée avec l'acteur Brad Pitt, dans une relation qui a attiré l'attention des médias du monde entier. Jolie et Pitt ont trois enfants adoptifs, Maddox, Pax et Zahara, ainsi que trois enfants biologiques, Shiloh, Knox et Vivienne. Ils ont divorcés en septembre 2016."
+                    "biography": "Angelina Jolie est une actrice américaine. Elle a reçu un Academy Award, deux Screen Actors Guild Awards et trois Golden Globe Awards. Angelina Jolie a soutenu des causes humanitaires dans le monde entier et est connue pour son travail avec les réfugiés en tant qu'ambassadrice de la paix du Haut Commissariat des Nations Unies pour les Réfugiés (HCNUR). Elle a été citée comme l'une des plus belles femmes du monde et sa vie hors écran est largement diffusée.\n\nBien qu'elle ait fait ses débuts à l'écran dès son enfance aux côtés de son père Jon Voight dans le film Lookin' to Get Out (1982), la carrière d'actrice d'Angelina Jolie a commencé sérieusement une décennie plus tard avec la production à petit budget Cyborg 2 (1993). Son premier rôle principal dans un grand film a été dans Hackers (1995). Elle a joué dans les films biographiques acclamés par la critique George Wallace (1997) et Gia (1998), et a remporté un Oscar du meilleur second rôle féminin pour sa performance dans le drame Une Vie volée (1999). Elle a atteint une plus grande notoriété après son interprétation de l'héroïne du jeu vidéo Lara Croft dans Lara Croft : Tomb Raider (2001), et s'est depuis établie comme l'une des actrices les plus connues et les mieux payées d'Hollywood. Elle a connu ses plus grands succès commerciaux avec la comédie d'action Mr. & Mrs. Smith (2005) et le film d'animation Kung Fu Panda (2008).\n\nDivorcée des acteurs Jonny Lee Miller et Billy Bob Thornton, Jolie s'est remariée avec l'acteur Brad Pitt, dans une relation qui a attiré l'attention des médias du monde entier. Jolie et Pitt ont trois enfants adoptifs, Maddox, Pax et Zahara, ainsi que trois enfants biologiques, Shiloh, Knox et Vivienne. Ils ont divorcés en septembre 2016.",
+                    "name": "",
+                    "primary": false
                 }
             },
             {
@@ -6472,7 +6498,9 @@
                 "name": "普通话",
                 "english_name": "Mandarin",
                 "data": {
-                    "biography": ""
+                    "biography": "安祖蓮娜·祖莉的父親是奧斯卡影帝強沃特，但很小的時候父母就離異，因此與父親關係長期不和，甚至與父親斷絕父女關係，和母親同住。由於從小生活在好萊塢，安潔莉娜很早就和演藝圈有所接觸，七歲時就成為童星，也曾經擔任過模特兒。1993 年，安潔莉娜進入電影圈，在演了一些反映平淡的影片後，終於在 1997 年因為在電視電影《風雲傳奇》中一鳴驚人，獲得金球獎電視電影類最佳女配角。緊接著她演出的另一部電視電影《霓裳情挑》又為她再次獲得金球獎，而 1999 年她在電影《我有冇問題》中，飾演一位個性狂野偏執但是內心又相當脆弱的精神病患，精採的演出，獲得該年奧斯卡金像獎最佳女配角獎。年輕的安潔莉娜從此名聲鵲起，成為好萊塢後起之秀中的佼佼者。\n\n2001 年的《盜墓者羅拉》，讓安潔莉娜成為好萊塢首屈一指的動作女星。這段期間安潔莉娜與演員兼導演比利鮑伯松頓閃電結婚，在 2003 年 5 月離婚。2004 年，她與布萊德彼特因拍攝《史密夫決戰史密妻》傳出戀情，展開了至今仍是八卦媒體爭相追逐的「布裘戀」。在持續推出許多賣座動作片後， 2007 年，她在一部小成本電影《追擊枕邊謎》中，演出一位丈夫遭恐怖份子挾持的女記者，不同於以往的演出，讓安潔莉娜獲得金球獎最佳女主角的提名。2008 年她在大導演克林伊斯威特的《換命謊言》中飾演一位一心要找回失蹤兒子的單親媽媽，獲得奧斯卡最佳女主角提名。\n\n除了演出多部票房成功的電影外，裘莉也積極投身慈善事業，經常親自深入難民區探望可憐的災名，也領養了多位第三世界國家的孤兒，更獲選為聯合國親善大使。而當她拾起導演筒，也關懷世界其他角落、生活在戰爭中的人們。《愛在血淚交織時》和《他們先殺了我父親：柬埔寨女孩的回憶》都獲得金球獎的最佳外語片獎提名。期間還執導人性黑暗與光輝交相輝映的《非凡生命歷》。\n\n2006 年她與布萊德彼特生下一女，三年後又生下一對龍鳳胎，享受著熱鬧的家庭生活。2009 年，安潔莉娜也開始與父親接觸，父女關係得到緩和。2019 年，她與布萊德彼特完成離婚手續。戲內她從《亞歷山大帝》的母親、《貝武夫：北海的詛咒》食人魔的母親，到《黑魔後：沉睡魔咒》當起奧蘿拉公主沒有血緣的母親。戲裏戲外一路走來，母親的角色讓她感觸良多。未來將加入漫威宇宙，為觀眾帶來最新的超能力英雄《永恆族》。",
+                    "name": "安祖蓮娜·祖莉",
+                    "primary": false
                 }
             },
             {
@@ -6481,7 +6509,9 @@
                 "name": "普通话",
                 "english_name": "Mandarin",
                 "data": {
-                    "biography": "安吉丽娜·朱莉（Angelina Jolie）是美国女演员。她获得了奥斯卡金像奖，两个电影演员协会奖和三个金球奖。朱莉在世界各地促进人道主义事业，并以其与难民的合作而著名，担任联合国难民事务高级专员（难民署）的亲善大使。她被公认为世界上最美丽的女人之一，她的屏外生活被广泛报道。\n\n尽管她在孩提时代与父亲乔恩·沃伊特（Jon Voight）在1982年的电影《 Lookin'to Get Out》中首次亮相，但朱莉的演艺生涯始于十年后的低预算制作《机械人2》（Cyborg 2）。她在大型电影中的第一个主角是《骇客》（1995年）。她出演了备受赞誉的传记电影乔治·华莱士（George Wallace）（1997）和吉亚（Gia）（1998），并因其在电视剧《女孩中断》（1999）中的表演而获得奥斯卡最佳女配角奖。朱莉（Jolie）在电视游戏女主角拉拉·克罗夫特（Lara Croft）在《劳拉·克罗夫特：古墓丽影》（2001）中饰演后，声名wider起，自此成为好莱坞最知名，收入最高的女演员之一。她凭借喜剧片《史密斯夫妇》（Mr.＆Smiths）（2005）和动画电影《功夫熊猫》（2008）取得了最大的商业成功。\n\n朱莉与演员乔尼·李·米勒（Jonny Lee Miller）和比利·鲍勃·桑顿（Billy Bob Thornton）离婚，目前与演员布拉德·皮特（Brad Pitt）住在一起，这种关系引起了全世界媒体的关注。朱莉（Julie）和皮特（Pitt）有3个收养子女，即Maddox，Pax和Zahara，还有3个亲生子女，分别是Shiloh，Knox和Vivienne。"
+                    "biography": "安吉丽娜·朱莉（Angelina Jolie）是美国女演员。她获得了奥斯卡金像奖，两个电影演员协会奖和三个金球奖。朱莉在世界各地促进人道主义事业，并以其与难民的合作而著名，担任联合国难民事务高级专员（难民署）的亲善大使。她被公认为世界上最美丽的女人之一，她的屏外生活被广泛报道。\n\n尽管她在孩提时代与父亲乔恩·沃伊特（Jon Voight）在1982年的电影《 Lookin'to Get Out》中首次亮相，但朱莉的演艺生涯始于十年后的低预算制作《机械人2》（Cyborg 2）。她在大型电影中的第一个主角是《骇客》（1995年）。她出演了备受赞誉的传记电影乔治·华莱士（George Wallace）（1997）和吉亚（Gia）（1998），并因其在电视剧《女孩中断》（1999）中的表演而获得奥斯卡最佳女配角奖。朱莉（Jolie）在电视游戏女主角拉拉·克罗夫特（Lara Croft）在《劳拉·克罗夫特：古墓丽影》（2001）中饰演后，声名wider起，自此成为好莱坞最知名，收入最高的女演员之一。她凭借喜剧片《史密斯夫妇》（Mr.＆Smiths）（2005）和动画电影《功夫熊猫》（2008）取得了最大的商业成功。\n\n朱莉与演员乔尼·李·米勒（Jonny Lee Miller）和比利·鲍勃·桑顿（Billy Bob Thornton）离婚，目前与演员布拉德·皮特（Brad Pitt）住在一起，这种关系引起了全世界媒体的关注。朱莉（Julie）和皮特（Pitt）有3个收养子女，即Maddox，Pax和Zahara，还有3个亲生子女，分别是Shiloh，Knox和Vivienne。",
+                    "name": "安吉丽娜·朱莉",
+                    "primary": false
                 }
             },
             {
@@ -6490,7 +6520,9 @@
                 "name": "Polski",
                 "english_name": "Polish",
                 "data": {
-                    "biography": "Angelina Jolie pochodzi z aktorskiej rodziny. Jej ojcem jest laureat Oscara Jon Voight, a matką aktorka Marcheline Bertrand. Przed kamerami zadebiutowała w wieku 5 lat u boku swojego ojca w filmie \"Szukając wyjścia\". Kiedy skończyła 11 lat, rozpoczęła naukę w elitarnej szkole Lee Strasberg Theater Institute, gdzie uczyła się podstaw pracy aktora. W wieku 16 lat Jolie została zatrudniona jako modelka i w krótkim czasie jej twarz zaczęła być znana. Dzięki swojej urodzie często była angażowana do występów w wideoklipach, m.in. takich sław jak Meat Loaf, Lenny Kravitz czy The Rolling Stones. Z czasem jednak okazało się, że granie to jedyna dziedzina sztuki, która naprawdę pasjonuje Angelinę. Wstąpiła do trupy aktorskiej Met Theatre Group, gdzie u boku Eda Harrisa i Holly Hunter doskonaliła swój warsztat. Swoją pierwszą poważną rolę Jolie zagrała w roku 1993 w obrazie \"Cyborg 2: Szklany cień\". Niestety przeszła ona bez echa. Pierwsze dobre recenzje Angelina dostała dopiero w 1995 po premierze filmu \"Hakerzy\". Obraz okazał się niewypałem, ale krytycy zgodnie stwierdzili, że kreacja, którą stworzyła Jolie, zasługuje na uznanie. Mimo pochlebnych opinii na swoją wielką szansę aktorka musiała poczekać jeszcze dwa lata. W 1997 roku wystąpiła u boku Gary'ego Sinise'a w telewizyjnym obrazie \"George Wallace\". Za rolę Cornelii Angelina otrzymała Złoty Glob, a jej nazwisko stało się znane w filmowym światku. Dwa lata później Jolie zdobyła kolejny Złoty Glob, tym razem już dla najlepszej aktorki pierwszego planu, za kreację, którą stworzyła w obrazie \"Gia\". Swoją pozycję gwiazdy Jolie ugruntowała, zdobywając Oscara za rolę w filmie \"Przerwana lekcja muzyki\". W kolejnych latach aktorka wystąpiła m.in. w \"Lara Croft: Tomb Raider\", \"Oszukanej\", \"Salt\" czy \"Czarownicy\". Angelina Jolie dała się poznać także jako reżyserka, takimi obrazami jak \"Niezłomny\" czy \"Nad morzem\", w którym zagrała również główną rolę żeńską u boku swego ówczesnego męża Brada Pitta. Para była małżeństwem w latach 2014-2019 i doczekała się trójki biologicznych oraz trójki adoptowanych dzieci."
+                    "biography": "Angelina Jolie pochodzi z aktorskiej rodziny. Jej ojcem jest laureat Oscara Jon Voight, a matką aktorka Marcheline Bertrand. Przed kamerami zadebiutowała w wieku 5 lat u boku swojego ojca w filmie \"Szukając wyjścia\". Kiedy skończyła 11 lat, rozpoczęła naukę w elitarnej szkole Lee Strasberg Theater Institute, gdzie uczyła się podstaw pracy aktora. W wieku 16 lat Jolie została zatrudniona jako modelka i w krótkim czasie jej twarz zaczęła być znana. Dzięki swojej urodzie często była angażowana do występów w wideoklipach, m.in. takich sław jak Meat Loaf, Lenny Kravitz czy The Rolling Stones. Z czasem jednak okazało się, że granie to jedyna dziedzina sztuki, która naprawdę pasjonuje Angelinę. Wstąpiła do trupy aktorskiej Met Theatre Group, gdzie u boku Eda Harrisa i Holly Hunter doskonaliła swój warsztat. Swoją pierwszą poważną rolę Jolie zagrała w roku 1993 w obrazie \"Cyborg 2: Szklany cień\". Niestety przeszła ona bez echa. Pierwsze dobre recenzje Angelina dostała dopiero w 1995 po premierze filmu \"Hakerzy\". Obraz okazał się niewypałem, ale krytycy zgodnie stwierdzili, że kreacja, którą stworzyła Jolie, zasługuje na uznanie. Mimo pochlebnych opinii na swoją wielką szansę aktorka musiała poczekać jeszcze dwa lata. W 1997 roku wystąpiła u boku Gary'ego Sinise'a w telewizyjnym obrazie \"George Wallace\". Za rolę Cornelii Angelina otrzymała Złoty Glob, a jej nazwisko stało się znane w filmowym światku. Dwa lata później Jolie zdobyła kolejny Złoty Glob, tym razem już dla najlepszej aktorki pierwszego planu, za kreację, którą stworzyła w obrazie \"Gia\". Swoją pozycję gwiazdy Jolie ugruntowała, zdobywając Oscara za rolę w filmie \"Przerwana lekcja muzyki\". W kolejnych latach aktorka wystąpiła m.in. w \"Lara Croft: Tomb Raider\", \"Oszukanej\", \"Salt\" czy \"Czarownicy\". Angelina Jolie dała się poznać także jako reżyserka, takimi obrazami jak \"Niezłomny\" czy \"Nad morzem\", w którym zagrała również główną rolę żeńską u boku swego ówczesnego męża Brada Pitta. Para była małżeństwem w latach 2014-2019 i doczekała się trójki biologicznych oraz trójki adoptowanych dzieci.",
+                    "name": "",
+                    "primary": false
                 }
             },
             {
@@ -6499,7 +6531,9 @@
                 "name": "Español",
                 "english_name": "Spanish",
                 "data": {
-                    "biography": "Angelina Jolie Voight es una actriz, modelo, filántropa, actriz de voz, directora, guionista y activista por los derechos de las mujeres estadounidenses que también posee la nacionalidad camboyana. A lo largo de su carrera, Jolie ha recibido varios reconocimientos por sus logros actorales, entre ellos dos Premios Óscar (uno a mejor actriz y el premio humanitario) y tres Globos de Oro. Desde 2012 es Enviada Especial del Alto Comisionado de las Naciones Unidas para los Refugiados. En 2016 la London School of Economics anunció que Jolie sería profesora de un nuevo tipo de máster sobre \"Las mujeres, la paz y la seguridad\" con el objetivo de promover la igualdad de sexos y ayudar a las mujeres afectadas por los conflictos de todo el mundo."
+                    "biography": "Angelina Jolie Voight es una actriz, modelo, filántropa, actriz de voz, directora, guionista y activista por los derechos de las mujeres estadounidenses que también posee la nacionalidad camboyana. A lo largo de su carrera, Jolie ha recibido varios reconocimientos por sus logros actorales, entre ellos dos Premios Óscar (uno a mejor actriz y el premio humanitario) y tres Globos de Oro. Desde 2012 es Enviada Especial del Alto Comisionado de las Naciones Unidas para los Refugiados. En 2016 la London School of Economics anunció que Jolie sería profesora de un nuevo tipo de máster sobre \"Las mujeres, la paz y la seguridad\" con el objetivo de promover la igualdad de sexos y ayudar a las mujeres afectadas por los conflictos de todo el mundo.",
+                    "name": "",
+                    "primary": false
                 }
             },
             {
@@ -6508,7 +6542,9 @@
                 "name": "Český",
                 "english_name": "Czech",
                 "data": {
-                    "biography": ""
+                    "biography": "",
+                    "name": "",
+                    "primary": false
                 }
             },
             {
@@ -6517,7 +6553,9 @@
                 "name": "العربية",
                 "english_name": "Arabic",
                 "data": {
-                    "biography": "أنجلينا جولي ممثلة أمريكية. حصلت على جائزة الأوسكار وجائزتي نقابة ممثلي الشاشة وثلاث جوائز غولدن غلوب. روجت جولي للقضايا الإنسانية في جميع أنحاء العالم ، وهي معروفة بعملها مع اللاجئين كسفيرة للنوايا الحسنة لمفوضية الأمم المتحدة السامية لشؤون اللاجئين.\n\nتم الاستشهاد بها كواحدة من أجمل النساء في العالم ويتم الإبلاغ عن حياتها خارج الشاشة على نطاق واسع.\n\nعلى الرغم من أنها ظهرت لأول مرة على الشاشة عندما كانت طفلة إلى جانب والدها جون فويت في فيلم 1982 Lookin 'to Get Out ، بدأت مهنة جولي في التمثيل بجدية بعد عقد من الزمن بإنتاجها منخفض الميزانية Cyborg 2 (1993).\n\nكان أول دور قيادي لها في فيلم كبير في فيلم Hackers (1995). لعبت دور البطولة في أفلام السيرة الذاتية التي نالت استحسانا كبيرا جورج والاس (1997) وجيا (1998) ، وفازت بجائزة الأوسكار لأفضل ممثلة مساعدة عن أدائها في الدراما Girl، Interrupt (1999).\n\nحققت جولي شهرة واسعة بعد أن لعبت دور بطلة ألعاب الفيديو لارا كروفت في فيلم Lara Croft: Tomb Raider (2001) ، ومنذ ذلك الحين رسخت مكانتها كواحدة من أشهر الممثلات وأكثرها أجراً في هوليوود. لقد حققت أكبر نجاحاتها التجارية مع فيلم الحركة الكوميدي Mr.\n\nسميث (2005) وفيلم الرسوم المتحركة Kung Fu Panda (2008)"
+                    "biography": "أنجلينا جولي ممثلة أمريكية. حصلت على جائزة الأوسكار وجائزتي نقابة ممثلي الشاشة وثلاث جوائز غولدن غلوب. روجت جولي للقضايا الإنسانية في جميع أنحاء العالم ، وهي معروفة بعملها مع اللاجئين كسفيرة للنوايا الحسنة لمفوضية الأمم المتحدة السامية لشؤون اللاجئين.\n\nتم الاستشهاد بها كواحدة من أجمل النساء في العالم ويتم الإبلاغ عن حياتها خارج الشاشة على نطاق واسع.\n\nعلى الرغم من أنها ظهرت لأول مرة على الشاشة عندما كانت طفلة إلى جانب والدها جون فويت في فيلم 1982 Lookin 'to Get Out ، بدأت مهنة جولي في التمثيل بجدية بعد عقد من الزمن بإنتاجها منخفض الميزانية Cyborg 2 (1993).\n\nكان أول دور قيادي لها في فيلم كبير في فيلم Hackers (1995). لعبت دور البطولة في أفلام السيرة الذاتية التي نالت استحسانا كبيرا جورج والاس (1997) وجيا (1998) ، وفازت بجائزة الأوسكار لأفضل ممثلة مساعدة عن أدائها في الدراما Girl، Interrupt (1999).\n\nحققت جولي شهرة واسعة بعد أن لعبت دور بطلة ألعاب الفيديو لارا كروفت في فيلم Lara Croft: Tomb Raider (2001) ، ومنذ ذلك الحين رسخت مكانتها كواحدة من أشهر الممثلات وأكثرها أجراً في هوليوود. لقد حققت أكبر نجاحاتها التجارية مع فيلم الحركة الكوميدي Mr.\n\nسميث (2005) وفيلم الرسوم المتحركة Kung Fu Panda (2008)",
+                    "name": "أنجلينا جولي",
+                    "primary": false
                 }
             },
             {
@@ -6526,7 +6564,9 @@
                 "name": "Català",
                 "english_name": "Catalan",
                 "data": {
-                    "biography": "Angelina Jolie Voight (Los Angeles, Califòrnia, 4 de juny de 1975) és una actriu estatunidenca de cinema i televisió, guanyadora d'un Òscar a la millor actriu secundària i de tres Globus d'Or.\n\nDe nena, solia veure pel·lícules amb la seva mare i va ser això, més que l'exitosa carrera del seu pare, el que va despertar el seu interès per l'actuació, encara que va tenir un petit paper al costat del seu pare a Lookin' to Get Out, el 1982 als set anys."
+                    "biography": "Angelina Jolie Voight (Los Angeles, Califòrnia, 4 de juny de 1975) és una actriu estatunidenca de cinema i televisió, guanyadora d'un Òscar a la millor actriu secundària i de tres Globus d'Or.\n\nDe nena, solia veure pel·lícules amb la seva mare i va ser això, més que l'exitosa carrera del seu pare, el que va despertar el seu interès per l'actuació, encara que va tenir un petit paper al costat del seu pare a Lookin' to Get Out, el 1982 als set anys.",
+                    "name": "",
+                    "primary": false
                 }
             },
             {
@@ -6535,7 +6575,9 @@
                 "name": "Italiano",
                 "english_name": "Italian",
                 "data": {
-                    "biography": "Angelina Jolie è un'attrice americana. Ha ricevuto un Oscar, due Screen Actors Guild Awards e tre Golden Globe. Jolie ha promosso cause umanitarie in tutto il mondo ed è nota per il suo lavoro con i rifugiati come ambasciatrice di buona volontà per l'Alto Commissariato delle Nazioni Unite per i Rifugiati (UNHCR). È stata citata come una delle donne più belle del mondo e la sua vita fuori dallo schermo è ampiamente riportata.\n\nSebbene abbia fatto il suo debutto sullo schermo da bambina insieme a suo padre Jon Voight nel film del 1982 Lookin' to Get Out, la carriera di attrice di Jolie è iniziata sul serio un decennio dopo con la produzione a basso budget Cyborg 2 (1993). Il suo primo ruolo da protagonista in un film importante è stato in Hackers (1995). Ha recitato nei film biografici acclamati dalla critica George Wallace (1997) e Gia (1998), e ha vinto un Academy Award come migliore attrice non protagonista per la sua interpretazione nel dramma Girl, Interrupted (1999). Jolie ha raggiunto una fama più ampia dopo la sua interpretazione dell'eroina dei videogiochi Lara Croft in Lara Croft: Tomb Raider (2001), e da allora si è affermata come una delle attrici più conosciute e più pagate di Hollywood. Ha avuto i suoi più grandi successi commerciali con la commedia d'azione Mr. & Mrs. Smith (2005) e il film d'animazione Kung Fu Panda (2008).\n\nDivorziata dagli attori Jonny Lee Miller e Billy Bob Thornton, Jolie attualmente vive con l'attore Brad Pitt, in una relazione che ha attirato l'attenzione dei media di tutto il mondo. Jolie e Pitt hanno tre figli adottivi, Maddox, Pax e Zahara, oltre a tre figli biologici, Shiloh, Knox e Vivienne."
+                    "biography": "Angelina Jolie è un'attrice americana. Ha ricevuto un Oscar, due Screen Actors Guild Awards e tre Golden Globe. Jolie ha promosso cause umanitarie in tutto il mondo ed è nota per il suo lavoro con i rifugiati come ambasciatrice di buona volontà per l'Alto Commissariato delle Nazioni Unite per i Rifugiati (UNHCR). È stata citata come una delle donne più belle del mondo e la sua vita fuori dallo schermo è ampiamente riportata.\n\nSebbene abbia fatto il suo debutto sullo schermo da bambina insieme a suo padre Jon Voight nel film del 1982 Lookin' to Get Out, la carriera di attrice di Jolie è iniziata sul serio un decennio dopo con la produzione a basso budget Cyborg 2 (1993). Il suo primo ruolo da protagonista in un film importante è stato in Hackers (1995). Ha recitato nei film biografici acclamati dalla critica George Wallace (1997) e Gia (1998), e ha vinto un Academy Award come migliore attrice non protagonista per la sua interpretazione nel dramma Girl, Interrupted (1999). Jolie ha raggiunto una fama più ampia dopo la sua interpretazione dell'eroina dei videogiochi Lara Croft in Lara Croft: Tomb Raider (2001), e da allora si è affermata come una delle attrici più conosciute e più pagate di Hollywood. Ha avuto i suoi più grandi successi commerciali con la commedia d'azione Mr. & Mrs. Smith (2005) e il film d'animazione Kung Fu Panda (2008).\n\nDivorziata dagli attori Jonny Lee Miller e Billy Bob Thornton, Jolie attualmente vive con l'attore Brad Pitt, in una relazione che ha attirato l'attenzione dei media di tutto il mondo. Jolie e Pitt hanno tre figli adottivi, Maddox, Pax e Zahara, oltre a tre figli biologici, Shiloh, Knox e Vivienne.",
+                    "name": "",
+                    "primary": false
                 }
             },
             {
@@ -6544,7 +6586,9 @@
                 "name": "Tiếng Việt",
                 "english_name": "Vietnamese",
                 "data": {
-                    "biography": ""
+                    "biography": "",
+                    "name": "",
+                    "primary": false
                 }
             },
             {
@@ -6553,7 +6597,9 @@
                 "name": "Deutsch",
                 "english_name": "German",
                 "data": {
-                    "biography": "Angelina Jolie, DCMG (* 4. Juni 1975 als Angelina Jolie Voight in Los Angeles, Kalifornien) ist eine US-amerikanische Schauspielerin, Filmregisseurin, Filmproduzentin und Drehbuchautorin. Während ihrer Ehe mit Brad Pitt trug sie den Namen Angelina Jolie Pitt.\n\nSie wurde mit der Darstellung der Videospielheldin Lara Croft in Lara Croft: Tomb Raider (2001) international bekannt. Weitere kommerzielle Erfolge hatte sie mit den Filmen Mr. & Mrs. Smith (2005), Wanted (2008), Salt (2010) und Maleficent – Die dunkle Fee (2014). Für ihre schauspielerischen Leistungen erhielt Jolie drei Golden Globes, zwei Screen Actors Guild Awards und für ihre Rolle einer psychisch Kranken in dem Film Durchgeknallt (1999) einen Oscar als beste Nebendarstellerin. Mit dem Kriegsdrama In the Land of Blood and Honey gab Jolie 2011 ihr Debüt als Spielfilmregisseurin und Drehbuchautorin.\n\nVon 2012 bis 2022 war sie Sondergesandte des UN-Flüchtlingshochkommissars Filippo Grandi."
+                    "biography": "Angelina Jolie, DCMG (* 4. Juni 1975 als Angelina Jolie Voight in Los Angeles, Kalifornien) ist eine US-amerikanische Schauspielerin, Filmregisseurin, Filmproduzentin und Drehbuchautorin. Während ihrer Ehe mit Brad Pitt trug sie den Namen Angelina Jolie Pitt.\n\nSie wurde mit der Darstellung der Videospielheldin Lara Croft in Lara Croft: Tomb Raider (2001) international bekannt. Weitere kommerzielle Erfolge hatte sie mit den Filmen Mr. & Mrs. Smith (2005), Wanted (2008), Salt (2010) und Maleficent – Die dunkle Fee (2014). Für ihre schauspielerischen Leistungen erhielt Jolie drei Golden Globes, zwei Screen Actors Guild Awards und für ihre Rolle einer psychisch Kranken in dem Film Durchgeknallt (1999) einen Oscar als beste Nebendarstellerin. Mit dem Kriegsdrama In the Land of Blood and Honey gab Jolie 2011 ihr Debüt als Spielfilmregisseurin und Drehbuchautorin.\n\nVon 2012 bis 2022 war sie Sondergesandte des UN-Flüchtlingshochkommissars Filippo Grandi.",
+                    "name": "",
+                    "primary": false
                 }
             },
             {
@@ -6562,7 +6608,9 @@
                 "name": "עִבְרִית",
                 "english_name": "Hebrew",
                 "data": {
-                    "biography": ""
+                    "biography": "אנג'לינה ג'ולי היא שחקנית אמריקאית. היא קיבלה פרס אוסקר, שני פרסי גילדת שחקני המסך ושלושה פרסי גלובוס הזהב. ג'ולי קידמה מטרות הומניטריות ברחבי העולם, והיא ידועה בעבודתה עם פליטים כשגרירת רצון טוב של הנציב העליון של האו\"ם לפליטים (UNHCR). היא צוטטה כאחת הנשים היפות בעולם וחייה מחוץ למסך מדווחים בהרחבה.\n\nעל אף שעשתה את הופעת הבכורה שלה כילדה לצד אביה ג'ון וייט בסרט \"Lookin' to Get Out\" משנת 1982, קריירת המשחק של ג'ולי החלה ברצינות עשור לאחר מכן עם ההפקה דל התקציב Cyborg 2 (1993). התפקיד הראשי הראשון שלה בסרט גדול היה בהאקרים (1995). היא שיחקה בסרטים הביוגרפיים עטורי הביקורות ג'ורג' וואלאס (1997) וג'יה (1998), וזכתה בפרס אוסקר לשחקנית המשנה הטובה ביותר על משחקה בדרמה \"נערה, מופרעת\" (1999). ג'ולי זכתה לתהילה רחבה יותר לאחר גילומה של גיבורת משחקי הווידאו לארה קרופט ב-Lara Croft: Tomb Raider (2001), ומאז ביססה את עצמה כאחת השחקניות המוכרות והמרוויחות ביותר בהוליווד. היא זכתה להצלחות המסחריות הגדולות ביותר שלה עם קומדיית הפעולה מר וגברת סמית' (2005) וסרט האנימציה קונג פו פנדה (2008).\n\nגרושה מהשחקנים ג'וני לי מילר ובילי בוב תורנטון, ג'ולי חיה כיום עם השחקן בראד פיט, במערכת יחסים שמשכה תשומת לב תקשורתית עולמית. לג'ולי ולפיט יש שלושה ילדים מאומצים, מדוקס, פאקס וזהרה, וכן שלושה ילדים ביולוגיים, שילה, נוקס וויויאן.",
+                    "name": "אנג'לינה ג'ולי",
+                    "primary": false
                 }
             },
             {
@@ -6571,7 +6619,273 @@
                 "name": "فارسی",
                 "english_name": "Persian",
                 "data": {
-                    "biography": "آنجلینا جولی بازیگر، تهیه کننده و فیلمساز آمریکایی متولد ۴ ژوئن ۱۹۷۵ در لس آنجلس است. او از سال ۱۹۸۲ فعالیت خود را آغاز نمود و در دانشگاه نیویورک و موسسه تئاتر استارزبرگ تحصیل کرد. او تاکنون موفق به دریافت دو جایزه اسکار، دو جایزه گیلد و سه جایزه گلدن گلوب شده است. از جولی به عنوان یکی از پردرآمدترین بازیگران هالیوود یاد می شود و نخستین بار در سنین کودکی و همراه با پدرش در مقابل دوربین قرار گرفت. جولی در کنار فعالیت های هنری خود، در حوزه اقدامات بشر دوستانه نیز فعال است و از او بارها تقدیر شده است.\n\nآنجلینا جولی سابقه فعالیت در آثاری همچون جاودانگان، کسانی که آرزو دارند من بمیرم، به دور دست ها بیا، ایوان یکی یدونه، داستان کوسه، پاندای کونگ فو کار ۳، پاندای کونگ فو کار ۲، پاندای کونگ فو کار، افسونگر شرور: سردسته اهریمنان، جانی، افسونگر شرور، سرقت در ۶۰ ثانیه، همزاد، شکست ناپذیر، بیوولف و آقا و خانم اسمیت را در کارنامه هنری خود دارد."
+                    "biography": "آنجلینا جولی بازیگر، تهیه کننده و فیلمساز آمریکایی متولد ۴ ژوئن ۱۹۷۵ در لس آنجلس است. او از سال ۱۹۸۲ فعالیت خود را آغاز نمود و در دانشگاه نیویورک و موسسه تئاتر استارزبرگ تحصیل کرد. او تاکنون موفق به دریافت دو جایزه اسکار، دو جایزه گیلد و سه جایزه گلدن گلوب شده است. از جولی به عنوان یکی از پردرآمدترین بازیگران هالیوود یاد می شود و نخستین بار در سنین کودکی و همراه با پدرش در مقابل دوربین قرار گرفت. جولی در کنار فعالیت های هنری خود، در حوزه اقدامات بشر دوستانه نیز فعال است و از او بارها تقدیر شده است.\n\nآنجلینا جولی سابقه فعالیت در آثاری همچون جاودانگان، کسانی که آرزو دارند من بمیرم، به دور دست ها بیا، ایوان یکی یدونه، داستان کوسه، پاندای کونگ فو کار ۳، پاندای کونگ فو کار ۲، پاندای کونگ فو کار، افسونگر شرور: سردسته اهریمنان، جانی، افسونگر شرور، سرقت در ۶۰ ثانیه، همزاد، شکست ناپذیر، بیوولف و آقا و خانم اسمیت را در کارنامه هنری خود دارد.",
+                    "name": "آنجلینا جولی",
+                    "primary": false
+                }
+            },
+            {
+                "iso_3166_1": "JP",
+                "iso_639_1": "ja",
+                "name": "日本語",
+                "english_name": "Japanese",
+                "data": {
+                    "biography": "",
+                    "name": "アンジェリーナ・ジョリー",
+                    "primary": false
+                }
+            },
+            {
+                "iso_3166_1": "TR",
+                "iso_639_1": "tr",
+                "name": "Türkçe",
+                "english_name": "Turkish",
+                "data": {
+                    "biography": "Angelina Jolie Voight, 4 Haziran 1975 tarihinde Los Angeles, Kaliforniya, ABD'de dünyaya gelmiştir. Sanatçı bir aileden gelen Jolie'nin babası Oscar ödüllü aktör Jon Voight, annesi ise aktris Marcheline Bertrand'dır. Genç yaşlarında Lee Strasberg Tiyatro Enstitüsü'nde oyunculuk eğitimi alan Jolie, kariyerine ilk olarak küçük bütçeli filmler ve müzik videolarında yer alarak başlamıştır.\n\n1990'ların sonlarına doğru kariyerinde önemli bir çıkış yakalayan Jolie, özellikle televizyon filmi \"Gia\"da (1998) canlandırdığı süpermodel Gia Carangi rolüyle büyük beğeni toplamış ve bu performansıyla Altın Küre Ödülü kazanmıştır. Bu başarısını, Winona Ryder ile başrollerini paylaştığı \"Aklım Karıştı\" (Girl, Interrupted, 1999) filmiyle taçlandırmıştır. Bu filmdeki sosyopat Lisa Rowe karakteriyle En İyi Yardımcı Kadın Oyuncu dalında Akademi Ödülü (Oscar) kazanarak Hollywood'un en yetenekli genç aktrislerinden biri olarak kabul edilmiştir.\n\n2000'li yıllarda Angelina Jolie, hem aksiyon filmlerindeki başrolleriyle hem de dramatik performanslarıyla küresel bir süperstar haline gelmiştir. Popüler video oyunundan uyarlanan \"Lara Croft: Tomb Raider\" (2001) ve devam filmiyle uluslararası bir aksiyon ikonuna dönüşmüştür. \"Bay ve Bayan Smith\" (Mr. & Mrs. Smith, 2005), \"Wanted\" (2008) ve \"Ajan Salt\" (Salt, 2010) gibi filmlerle gişedeki başarısını sürdürmüştür. Aynı dönemde \"Güçlü Bir Yürek\" (A Mighty Heart, 2007) ve Clint Eastwood'un yönettiği \"Sahtekâr\" (Changeling, 2008) gibi filmlerdeki güçlü dramatik rolleriyle de eleştirmenlerden övgü almış, \"Sahtekâr\" ile En İyi Kadın Oyuncu Oscar'ına aday gösterilmiştir.\n\nOyunculuğun yanı sıra yönetmenliğe de adım atan Jolie, ilk uzun metrajlı filmi \"Kan ve Aşk\" (In the Land of Blood and Honey, 2011) ile Bosna Savaşı'na odaklanmıştır. Ardından \"Boyun Eğmez\" (Unbroken, 2014) ve Kamboçya soykırımını konu alan \"First They Killed My Father\" (2017) gibi tarihi ve sosyal içerikli filmler yöneterek bu alandaki yeteneğini ve tutkusunu ortaya koymuştur.\n\nAngelina Jolie'nin kariyerinin ve kamuoyu nezdindeki kimliğinin ayrılmaz bir parçası da uzun yıllardır sürdürdüğü insani yardım çalışmalarıdır. Birleşmiş Milletler Mülteciler Yüksek Komiserliği (UNHCR) ile 20 yılı aşkın süre çalışmış, İyi Niyet Elçisi ve ardından Özel Temsilci olarak dünyanın dört bir yanındaki çatışma bölgelerine ve mülteci kamplarına sayısız ziyaret gerçekleştirmiştir. Mültecilerin hakları, kadın hakları ve çocukların korunması gibi konularda küresel bir savunucu olarak aktif rol oynamaktadır.\n\nSon yıllarda \"Malefiz\" (Maleficent) serisi ve Marvel Sinematik Evreni filmi \"Eternals\" (2021) gibi büyük bütçeli yapımlarda yer almaya devam eden Jolie, aynı zamanda daha kişisel ve sanatsal projelere de odaklanmaktadır. Ünlü opera sanatçısı Maria Callas'ın hayatını konu alacak olan \"Maria\" filmi gibi merakla beklenen projelerle kariyerini sürdürmektedir.\n\nAngelina Jolie, Oscar ödüllü bir aktris, başarılı bir yönetmen ve dünya çapında tanınan bir insani yardım aktivisti olarak, günümüzün en etkili ve çok yönlü figürlerinden biridir. Hem sanatsal başarıları hem de küresel sorunlara olan duyarlılığıyla milyonlarca insana ilham vermektedir.",
+                    "name": "",
+                    "primary": false
+                }
+            },
+            {
+                "iso_3166_1": "IN",
+                "iso_639_1": "hi",
+                "name": "हिन्दी",
+                "english_name": "Hindi",
+                "data": {
+                    "biography": "",
+                    "name": "एंजेलिना जोली",
+                    "primary": false
+                }
+            },
+            {
+                "iso_3166_1": "IN",
+                "iso_639_1": "kn",
+                "name": "?????",
+                "english_name": "Kannada",
+                "data": {
+                    "biography": "",
+                    "name": "ಏಂಜೆಲಿನಾ ಜೋಲೀ",
+                    "primary": false
+                }
+            },
+            {
+                "iso_3166_1": "SG",
+                "iso_639_1": "zh",
+                "name": "普通话",
+                "english_name": "Mandarin",
+                "data": {
+                    "biography": "",
+                    "name": "安吉丽娜·卓莉",
+                    "primary": false
+                }
+            },
+            {
+                "iso_3166_1": "BD",
+                "iso_639_1": "bn",
+                "name": "বাংলা",
+                "english_name": "Bengali",
+                "data": {
+                    "biography": "",
+                    "name": "অ্যাঞ্জেলিনা জোলি",
+                    "primary": false
+                }
+            },
+            {
+                "iso_3166_1": "BY",
+                "iso_639_1": "be",
+                "name": "беларуская мова",
+                "english_name": "Belarusian",
+                "data": {
+                    "biography": "",
+                    "name": "Анджэліна Джалі",
+                    "primary": false
+                }
+            },
+            {
+                "iso_3166_1": "BG",
+                "iso_639_1": "bg",
+                "name": "български език",
+                "english_name": "Bulgarian",
+                "data": {
+                    "biography": "",
+                    "name": "Анджелина Джоли",
+                    "primary": false
+                }
+            },
+            {
+                "iso_3166_1": "AZ",
+                "iso_639_1": "az",
+                "name": "Azərbaycan",
+                "english_name": "Azerbaijani",
+                "data": {
+                    "biography": "",
+                    "name": "Ancelina Coli",
+                    "primary": false
+                }
+            },
+            {
+                "iso_3166_1": "IN",
+                "iso_639_1": "pa",
+                "name": "ਪੰਜਾਬੀ",
+                "english_name": "Punjabi",
+                "data": {
+                    "biography": "",
+                    "name": "ਅਨਜਲੀਨਾ ਜੋਲੀ",
+                    "primary": false
+                }
+            },
+            {
+                "iso_3166_1": "IN",
+                "iso_639_1": "te",
+                "name": "తెలుగు",
+                "english_name": "Telugu",
+                "data": {
+                    "biography": "",
+                    "name": "ఏంజలీనా జోలీ",
+                    "primary": false
+                }
+            },
+            {
+                "iso_3166_1": "IN",
+                "iso_639_1": "ta",
+                "name": "தமிழ்",
+                "english_name": "Tamil",
+                "data": {
+                    "biography": "",
+                    "name": "ஏஞ்சலினா ஜோலி",
+                    "primary": false
+                }
+            },
+            {
+                "iso_3166_1": "TH",
+                "iso_639_1": "th",
+                "name": "ภาษาไทย",
+                "english_name": "Thai",
+                "data": {
+                    "biography": "",
+                    "name": "แอนเจลีนา โจลี",
+                    "primary": false
+                }
+            },
+            {
+                "iso_3166_1": "PK",
+                "iso_639_1": "ur",
+                "name": "اردو",
+                "english_name": "Urdu",
+                "data": {
+                    "biography": "",
+                    "name": "انجلینا جولی",
+                    "primary": false
+                }
+            },
+            {
+                "iso_3166_1": "IN",
+                "iso_639_1": "mr",
+                "name": "",
+                "english_name": "Marathi",
+                "data": {
+                    "biography": "",
+                    "name": "अँजेलिना जोली",
+                    "primary": false
+                }
+            },
+            {
+                "iso_3166_1": "MN",
+                "iso_639_1": "mn",
+                "name": "",
+                "english_name": "Mongolian",
+                "data": {
+                    "biography": "",
+                    "name": "Анжелина Жоли",
+                    "primary": false
+                }
+            },
+            {
+                "iso_3166_1": "RS",
+                "iso_639_1": "sr",
+                "name": "Srpski",
+                "english_name": "Serbian",
+                "data": {
+                    "biography": "",
+                    "name": "Анђелина Жоли",
+                    "primary": false
+                }
+            },
+            {
+                "iso_3166_1": "LK",
+                "iso_639_1": "si",
+                "name": "සිංහල",
+                "english_name": "Sinhalese",
+                "data": {
+                    "biography": "",
+                    "name": "ඇන්ජලීනා ජොලී",
+                    "primary": false
+                }
+            },
+            {
+                "iso_3166_1": "MK",
+                "iso_639_1": "mk",
+                "name": "",
+                "english_name": "Macedonian",
+                "data": {
+                    "biography": "",
+                    "name": "Анџелина Џоли",
+                    "primary": false
+                }
+            },
+            {
+                "iso_3166_1": "IN",
+                "iso_639_1": "ml",
+                "name": "",
+                "english_name": "Malayalam",
+                "data": {
+                    "biography": "",
+                    "name": "ആഞ്ചലീന ജോളി",
+                    "primary": false
+                }
+            },
+            {
+                "iso_3166_1": "LV",
+                "iso_639_1": "lv",
+                "name": "Latviešu",
+                "english_name": "Latvian",
+                "data": {
+                    "biography": "",
+                    "name": "Andželīna Džolija",
+                    "primary": false
+                }
+            },
+            {
+                "iso_3166_1": "KZ",
+                "iso_639_1": "kk",
+                "name": "қазақ",
+                "english_name": "Kazakh",
+                "data": {
+                    "biography": "",
+                    "name": "Анджелина Джоли",
+                    "primary": false
+                }
+            },
+            {
+                "iso_3166_1": "KG",
+                "iso_639_1": "ky",
+                "name": "??????",
+                "english_name": "Kirghiz",
+                "data": {
+                    "biography": "",
+                    "name": "Анжелина Жоли",
+                    "primary": false
+                }
+            },
+            {
+                "iso_3166_1": "HY",
+                "iso_639_1": "hy",
+                "name": "",
+                "english_name": "Armenian",
+                "data": {
+                    "biography": "",
+                    "name": "Անջելինա Ջոլի",
+                    "primary": false
                 }
             }
         ]

--- a/tmdb-api/src/jvmTest/resources/tmdb3/tv/episode/tv_details_96677_s1e1.json
+++ b/tmdb-api/src/jvmTest/resources/tmdb3/tv/episode/tv_details_96677_s1e1.json
@@ -2513,5 +2513,459 @@
         ]
       }
     }
+  },
+  "translations": {
+    "translations": [
+      {
+        "iso_3166_1": "CZ",
+        "iso_639_1": "cs",
+        "name": "Český",
+        "english_name": "Czech",
+        "data": {
+          "name": "1. kapitola",
+          "overview": "Po mnoha letech se Assanovi naskytne možnost pomstít křivdu, která se stala jeho rodině, a to tím, že se pokusí ukrást diamantový náhrdelník. Loupež však dostane nečekaný zvrat."
+        }
+      },
+      {
+        "iso_3166_1": "DK",
+        "iso_639_1": "da",
+        "name": "Dansk",
+        "english_name": "Danish",
+        "data": {
+          "name": "Kapitel 1",
+          "overview": "Flere år efter en tragisk og uretfærdig hændelse vil Assane have hævn – og betale en gæld – ved at stjæle en diamanthalskæde, men kuppet tager en uventet drejning."
+        }
+      },
+      {
+        "iso_3166_1": "DE",
+        "iso_639_1": "de",
+        "name": "Deutsch",
+        "english_name": "German",
+        "data": {
+          "name": "Kapitel 1",
+          "overview": "Mit dem Diebstahl eines wertvollen Colliers will Assane eine schmerzliche alte Rechnung – und eine Schuld – begleichen. Doch der Coup nimmt eine unerwartete Wendung."
+        }
+      },
+      {
+        "iso_3166_1": "US",
+        "iso_639_1": "en",
+        "name": "English",
+        "english_name": "English",
+        "data": {
+          "name": "Chapter 1",
+          "overview": "Years after a tragic injustice, Assane seeks to settle a score — and a debt — by stealing a diamond necklace, but the heist takes an unexpected turn."
+        }
+      },
+      {
+        "iso_3166_1": "ES",
+        "iso_639_1": "es",
+        "name": "Español",
+        "english_name": "Spanish",
+        "data": {
+          "name": "Capítulo 1",
+          "overview": "Años después de una trágica injusticia, Assane se propone ajustar cuentas (y una deuda) robando un collar de diamantes, pero las cosas no salen según lo previsto."
+        }
+      },
+      {
+        "iso_3166_1": "FR",
+        "iso_639_1": "fr",
+        "name": "Français",
+        "english_name": "French",
+        "data": {
+          "name": "Chapitre 1",
+          "overview": "Hanté par l'injustice qui a frappé sa famille, Assane veut régler ses comptes en volant un collier de diamants. Mais rien ne se passe comme prévu."
+        }
+      },
+      {
+        "iso_3166_1": "HU",
+        "iso_639_1": "hu",
+        "name": "Magyar",
+        "english_name": "Hungarian",
+        "data": {
+          "name": "1. fejezet - A királynő nyaklánca",
+          "overview": "Sok évvel egy tragikus igazságtalanság után Assane rendezni kívánja a számlát, ezért ellop egy gyémánt nyakláncot, ám az akció váratlan fordulatot vesz."
+        }
+      },
+      {
+        "iso_3166_1": "IT",
+        "iso_639_1": "it",
+        "name": "Italiano",
+        "english_name": "Italian",
+        "data": {
+          "name": "Capitolo 1",
+          "overview": "Anni dopo una tragica ingiustizia, Assane vuole regolare i conti e un debito rubando un collier di diamanti... ma il colpo prende una piega inaspettata."
+        }
+      },
+      {
+        "iso_3166_1": "KR",
+        "iso_639_1": "ko",
+        "name": "한국어/조선말",
+        "english_name": "Korean",
+        "data": {
+          "name": "챕터 1",
+          "overview": "그가 오늘 밤 큰 한탕을 노린다. 훔칠 물건은 루브르 경매에 나올 마리 앙투아네트의 목걸이. 최고의 박물관을 뚫을 트릭과 반전은 이미 준비되었다. '빚'을 청산할 계획도."
+        }
+      },
+      {
+        "iso_3166_1": "NL",
+        "iso_639_1": "nl",
+        "name": "Nederlands",
+        "english_name": "Dutch",
+        "data": {
+          "name": "Hoofdstuk 1",
+          "overview": "Jaren na een onrechtvaardige gebeurtenis wil Assane een oude rekening (en schuld) vereffenen door een diamanten ketting te stelen maar de overval loopt onverwacht anders."
+        }
+      },
+      {
+        "iso_3166_1": "BR",
+        "iso_639_1": "pt",
+        "name": "Português",
+        "english_name": "Portuguese",
+        "data": {
+          "name": "Capítulo 1",
+          "overview": "Anos depois de uma trágica injustiça, Assane tenta acertar as contas – e quitar uma dívida – roubando um colar de diamante, mas o roubo não sai como esperado."
+        }
+      },
+      {
+        "iso_3166_1": "PT",
+        "iso_639_1": "pt",
+        "name": "Português",
+        "english_name": "Portuguese",
+        "data": {
+          "name": "Capítulo 1",
+          "overview": "Anos após uma trágica injustiça, Assane procura ajustar contas — e saldar uma dívida — ao roubar um colar de diamantes, mas o golpe sofre uma inesperada reviravolta."
+        }
+      },
+      {
+        "iso_3166_1": "RU",
+        "iso_639_1": "ru",
+        "name": "Pусский",
+        "english_name": "Russian",
+        "data": {
+          "name": "1 глава",
+          "overview": "Чтобы заплатить по счетам, а еще свести счеты спустя годы после трагической несправедливости, Ассан похищает бриллиантовое колье. Но дело принимает неожиданный оборот."
+        }
+      },
+      {
+        "iso_3166_1": "TR",
+        "iso_639_1": "tr",
+        "name": "Türkçe",
+        "english_name": "Turkish",
+        "data": {
+          "name": "No. 1",
+          "overview": "Trajik bir adaletsizlikten yıllar sonra, Assane elmas bir kolye çalarak hesabını ve bir borcu kapatmak ister, ancak soygun beklenmedik bir yola girer."
+        }
+      },
+      {
+        "iso_3166_1": "PL",
+        "iso_639_1": "pl",
+        "name": "Polski",
+        "english_name": "Polish",
+        "data": {
+          "name": "Rozdział 1",
+          "overview": "Wiele lat po doświadczeniu niesprawiedliwości Assane zamierza wyrównać rachunki i odebrać dług, kradnąc diamentowy naszyjnik. Jednak nie wszystko idzie zgodnie z planem."
+        }
+      },
+      {
+        "iso_3166_1": "CN",
+        "iso_639_1": "zh",
+        "name": "普通话",
+        "english_name": "Mandarin",
+        "data": {
+          "name": "第 1 章",
+          "overview": "悲惨不公的事件发生多年后，阿桑试图清算旧帐，顺便解决债务，方法是窃取一条钻石项链，然而这桩劫案的发展却出现意外的转折。"
+        }
+      },
+      {
+        "iso_3166_1": "TW",
+        "iso_639_1": "zh",
+        "name": "普通话",
+        "english_name": "Mandarin",
+        "data": {
+          "name": "第 1 章",
+          "overview": "悲慘不公的事件發生多年後，亞森試圖清算舊帳，順便解決債務，方法是竊取一條鑽石項鍊，然而這樁劫案的發展卻出現意外的轉折。"
+        }
+      },
+      {
+        "iso_3166_1": "UA",
+        "iso_639_1": "uk",
+        "name": "Український",
+        "english_name": "Ukrainian",
+        "data": {
+          "name": "Глава 1",
+          "overview": "Колись із ним вчинили несправедливо. Тепер Ассан шукає помсти. Він прагне поквитатися, викравши діамантове кольє. Але пограбування іде не за планом."
+        }
+      },
+      {
+        "iso_3166_1": "CA",
+        "iso_639_1": "fr",
+        "name": "Français",
+        "english_name": "French",
+        "data": {
+          "name": "Chapitre 1",
+          "overview": "Des années après une injustice tragique, Assane veut régler des comptes – et une dette – en volant un collier de diamants, mais la mission prend une tournure inattendue."
+        }
+      },
+      {
+        "iso_3166_1": "IL",
+        "iso_639_1": "he",
+        "name": "עִבְרִית",
+        "english_name": "Hebrew",
+        "data": {
+          "name": "פרשה 1",
+          "overview": "שנים לאחר שאירוע טרגי הרס את חייו, אסאן נחוש לסגור חשבון – וחוב גדול. הוא יוצא לגנוב שרשרת יהלומים היסטורית, אבל השוד משתבש בעקבות תפנית לא צפויה."
+        }
+      },
+      {
+        "iso_3166_1": "VN",
+        "iso_639_1": "vi",
+        "name": "Tiếng Việt",
+        "english_name": "Vietnamese",
+        "data": {
+          "name": "Chương 1",
+          "overview": "Nhiều năm sau bất công đầy bi kịch, Assane tìm cách đánh cắp sợi dây chuyền kim cương hòng trả thù và đòi lại món nợ xưa, nhưng vụ trộm đã bất ngờ chuyển hướng."
+        }
+      },
+      {
+        "iso_3166_1": "MX",
+        "iso_639_1": "es",
+        "name": "Español",
+        "english_name": "Spanish",
+        "data": {
+          "name": "Capítulo 1",
+          "overview": "Años después de una fatal injusticia, Assane busca saldar cuentas —y una deuda— robándose un collar de diamantes, pero el golpe tiene un desenlace imprevisto."
+        }
+      },
+      {
+        "iso_3166_1": "TH",
+        "iso_639_1": "th",
+        "name": "ภาษาไทย",
+        "english_name": "Thai",
+        "data": {
+          "name": "บทที่ 1",
+          "overview": "หลายปีหลังความอยุติธรรมนำพามาซึ่งโศกนาฏกรรม อัสซานหาทางปลดหนี้และสะสางบัญชีแค้นด้วยการขโมยสร้อยเพชรเส้นหนึ่ง ทว่าแผนโจรกรรมกลับมีเหตุให้พลิกผัน"
+        }
+      },
+      {
+        "iso_3166_1": "GR",
+        "iso_639_1": "el",
+        "name": "ελληνικά",
+        "english_name": "Greek",
+        "data": {
+          "name": "Κεφάλαιο 1",
+          "overview": "Χρόνια μετά από μια αδικία με τραγική κατάληξη, ο Ασάν θέλει να πάρει το αίμα του πίσω κλέβοντας ένα διαμαντένιο περιδέραιο, αλλά η ληστεία παίρνει μια απροσδόκητη τροπή."
+        }
+      },
+      {
+        "iso_3166_1": "JP",
+        "iso_639_1": "ja",
+        "name": "日本語",
+        "english_name": "Japanese",
+        "data": {
+          "name": "第1章",
+          "overview": "少年時代、理不尽な事件によって家族を失ったアサンは、過去の因縁と借金にかたをつけるため首飾りの窃盗を企む。だが事態は思わぬ方向に転がり出す。"
+        }
+      },
+      {
+        "iso_3166_1": "SA",
+        "iso_639_1": "ar",
+        "name": "العربية",
+        "english_name": "Arabic",
+        "data": {
+          "name": "فصل 1",
+          "overview": "بعد سنوات من ظلم مأساوي، يسعى \"أسان\" إلى تصفية حساب وسداد دين بسرقة عقد من الألماس، لكن عملية السرقة تأخذ منعطفًا لم يكن في الحسبان."
+        }
+      },
+      {
+        "iso_3166_1": "LT",
+        "iso_639_1": "lt",
+        "name": "Lietuvių",
+        "english_name": "Lithuanian",
+        "data": {
+          "name": "",
+          "overview": ""
+        }
+      },
+      {
+        "iso_3166_1": "BG",
+        "iso_639_1": "bg",
+        "name": "български език",
+        "english_name": "Bulgarian",
+        "data": {
+          "name": "",
+          "overview": ""
+        }
+      },
+      {
+        "iso_3166_1": "SK",
+        "iso_639_1": "sk",
+        "name": "Slovenčina",
+        "english_name": "Slovak",
+        "data": {
+          "name": "",
+          "overview": "Assane sa rozhodne ukradnúť diamantový náhrdelník, aby vyrovnal účty za dávnu tragickú krivdu a tiež zmazal dlh. Lenže lúpež sa nečakane zvrtne."
+        }
+      },
+      {
+        "iso_3166_1": "HR",
+        "iso_639_1": "hr",
+        "name": "Hrvatski",
+        "english_name": "Croatian",
+        "data": {
+          "name": "1. poglavlje",
+          "overview": "Mnogo godina nakon tragične nepravde Assane želi izravnati račune krađom dijamantne ogrlice, no pljačka krene u neočekivanom smjeru."
+        }
+      },
+      {
+        "iso_3166_1": "SE",
+        "iso_639_1": "sv",
+        "name": "svenska",
+        "english_name": "Swedish",
+        "data": {
+          "name": "Kapitel 1",
+          "overview": "Många år efter en tragisk orättvisa är Assane ute efter att göra upp – genom att stjäla ett diamanthalsband. Men kuppen tar en oväntad vändning."
+        }
+      },
+      {
+        "iso_3166_1": "ID",
+        "iso_639_1": "id",
+        "name": "Bahasa indonesia",
+        "english_name": "Indonesian",
+        "data": {
+          "name": "Bab 1",
+          "overview": "Bertahun-tahun usai mengalami ketidakadilan tragis, Assane berniat membayar dendam dan utang dengan mencuri kalung berlian. Namun, perampokannya berujung di luar dugaan."
+        }
+      },
+      {
+        "iso_3166_1": "RS",
+        "iso_639_1": "sr",
+        "name": "Srpski",
+        "english_name": "Serbian",
+        "data": {
+          "name": "",
+          "overview": ""
+        }
+      },
+      {
+        "iso_3166_1": "GE",
+        "iso_639_1": "ka",
+        "name": "ქართული",
+        "english_name": "Georgian",
+        "data": {
+          "name": "",
+          "overview": ""
+        }
+      },
+      {
+        "iso_3166_1": "IR",
+        "iso_639_1": "fa",
+        "name": "فارسی",
+        "english_name": "Persian",
+        "data": {
+          "name": "",
+          "overview": ""
+        }
+      },
+      {
+        "iso_3166_1": "HK",
+        "iso_639_1": "zh",
+        "name": "普通话",
+        "english_name": "Mandarin",
+        "data": {
+          "name": "第 1 章",
+          "overview": "悲慘不公的事件發生多年後，亞森試圖清算舊帳，順便解決債務，方法是竊取一條鑽石項鍊，然而這樁劫案的發展卻出現意外的轉折。"
+        }
+      },
+      {
+        "iso_3166_1": "SI",
+        "iso_639_1": "sl",
+        "name": "Slovenščina",
+        "english_name": "Slovenian",
+        "data": {
+          "name": "",
+          "overview": ""
+        }
+      },
+      {
+        "iso_3166_1": "MY",
+        "iso_639_1": "ms",
+        "name": "Bahasa melayu",
+        "english_name": "Malay",
+        "data": {
+          "name": "Babak 1",
+          "overview": "Bertahun-tahun selepas ketidakadilan tragis, Assane mahu melepaskan dendam — dan hutang — dengan mencuri rantai berlian, namun suatu mengejutkan berlaku ketika rompakan."
+        }
+      },
+      {
+        "iso_3166_1": "IN",
+        "iso_639_1": "hi",
+        "name": "हिन्दी",
+        "english_name": "Hindi",
+        "data": {
+          "name": "चैप्टर 1",
+          "overview": "एक दर्दनाक अन्याय के कई साल बाद, हीरों का हार चुराकर असान एक हिसाब — और एक एहसान — दोनों चुकता करना चाहता है, पर वह लूट एक अप्रत्याशित मोड़ ले लेती है."
+        }
+      },
+      {
+        "iso_3166_1": "RO",
+        "iso_639_1": "ro",
+        "name": "Română",
+        "english_name": "Romanian",
+        "data": {
+          "name": "Capitolul 1",
+          "overview": "La ani de zile după o injustiție cu urmări tragice, Assane vrea să regleze niște conturi furând un colier cu diamante, dar jaful ia o turnură neașteptată."
+        }
+      },
+      {
+        "iso_3166_1": "SG",
+        "iso_639_1": "zh",
+        "name": "普通话",
+        "english_name": "Mandarin",
+        "data": {
+          "name": "第 1 章",
+          "overview": "一起悲惨的不公正事件发生多年之后，阿桑试图通过窃取钻石项链进行报复并偿清债务，而抢劫行动却发生了意想不到的转折。"
+        }
+      },
+      {
+        "iso_3166_1": "AE",
+        "iso_639_1": "ar",
+        "name": "العربية",
+        "english_name": "Arabic",
+        "data": {
+          "name": "فصل 1",
+          "overview": "بعد سنوات من ظلم مأساوي، يسعى \"أسان\" إلى تصفية حساب وسداد دين بسرقة عقد من الألماس، لكن عملية السرقة تأخذ منعطفًا لم يكن في الحسبان."
+        }
+      },
+      {
+        "iso_3166_1": "FI",
+        "iso_639_1": "fi",
+        "name": "suomi",
+        "english_name": "Finnish",
+        "data": {
+          "name": "",
+          "overview": ""
+        }
+      },
+      {
+        "iso_3166_1": "BE",
+        "iso_639_1": "nl",
+        "name": "Nederlands",
+        "english_name": "Dutch",
+        "data": {
+          "name": "",
+          "overview": ""
+        }
+      },
+      {
+        "iso_3166_1": "ES",
+        "iso_639_1": "ca",
+        "name": "Català",
+        "english_name": "Catalan",
+        "data": {
+          "name": "",
+          "overview": ""
+        }
+      }
+    ]
   }
 }

--- a/tmdb-api/src/jvmTest/resources/tmdb3/tv/tv_details_96677.json
+++ b/tmdb-api/src/jvmTest/resources/tmdb3/tv/tv_details_96677.json
@@ -2461,5 +2461,549 @@
         ]
       }
     }
+  },
+  "translations": {
+    "translations": [
+      {
+        "iso_3166_1": "FR",
+        "iso_639_1": "fr",
+        "name": "Français",
+        "english_name": "French",
+        "data": {
+          "name": "",
+          "overview": "Inspiré par les aventures d'Arsène Lupin, le gentleman cambrioleur Assane Diop décide de venger son père d'une terrible injustice.",
+          "homepage": "",
+          "tagline": "Vous m'avez vu, mais vous ne m'avez pas regardé."
+        }
+      },
+      {
+        "iso_3166_1": "US",
+        "iso_639_1": "en",
+        "name": "English",
+        "english_name": "English",
+        "data": {
+          "name": "",
+          "overview": "Inspired by the adventures of Arsène Lupin, gentleman thief Assane Diop sets out to avenge his father for an injustice inflicted by a wealthy family.",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "CZ",
+        "iso_639_1": "cs",
+        "name": "Český",
+        "english_name": "Czech",
+        "data": {
+          "name": "",
+          "overview": "Zloděj gentleman Assane Diop se ve šlépějích Arsèna Lupina vydává pomstít příkoří, které jeho otci způsobila jedna bohatá rodina.",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "KR",
+        "iso_639_1": "ko",
+        "name": "한국어/조선말",
+        "english_name": "Korean",
+        "data": {
+          "name": "뤼팽",
+          "overview": "한 남자가 뼈아픈 배신을 겪은 가족을 위해 복수의 칼을 품는다. 그리고 새로운 전설이 시작된다. 오마르 시 주연으로, 괴도 아르센 뤼팽을 현대적으로 재해석한 작품.",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "IT",
+        "iso_639_1": "it",
+        "name": "Italiano",
+        "english_name": "Italian",
+        "data": {
+          "name": "Lupin",
+          "overview": "Ispirandosi alle avventure di Arsenio Lupin, il ladro gentiluomo Assane Diop decide di vendicare il padre per un'ingiustizia subita per colpa di una ricca famiglia.",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "BR",
+        "iso_639_1": "pt",
+        "name": "Português",
+        "english_name": "Portuguese",
+        "data": {
+          "name": "",
+          "overview": "Inspirado pelas aventuras de Arsène Lupin, o ladrão gentil Assane Diop quer se vingar de uma família rica por uma injustiça cometida contra o pai dele.",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "DE",
+        "iso_639_1": "de",
+        "name": "Deutsch",
+        "english_name": "German",
+        "data": {
+          "name": "",
+          "overview": "Inspiriert von den Abenteuern Arsène Lupins beschließt der Meisterdieb Assane Diop, seinen Vater zu rächen, dem von einer reichen Familie großes Unrecht zugefügt wurde.",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "PT",
+        "iso_639_1": "pt",
+        "name": "Português",
+        "english_name": "Portuguese",
+        "data": {
+          "name": "",
+          "overview": "Inspirado pelas aventuras de Arsène Lupin, o ladrão de casaca Assane Diop está decidido a vingar o pai por uma injustiça acometida por uma família abastada.",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "TR",
+        "iso_639_1": "tr",
+        "name": "Türkçe",
+        "english_name": "Turkish",
+        "data": {
+          "name": "",
+          "overview": "Arsen Lüpen'in maceralarından esinlenen kibar hırsız Assane Diop, varlıklı bir aile yüzünden haksızlığa uğrayan babasının intikamını almak için kolları sıvar.",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "HU",
+        "iso_639_1": "hu",
+        "name": "Magyar",
+        "english_name": "Hungarian",
+        "data": {
+          "name": "",
+          "overview": "Assane Diop, az úri tolvaj Arsène Lupin kalandjaiból merít ihletet, amikor bosszút áll az igazságtalanságokért, amelyeket egy gazdag család követett el az apja ellen.",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "DK",
+        "iso_639_1": "da",
+        "name": "Dansk",
+        "english_name": "Danish",
+        "data": {
+          "name": "",
+          "overview": "Inspireret af Arsène Lupins eventyr drager gentlemantyven Assane Diop ud for at hævne sin far for en uretfærdighed, der blev begået af en velhavende familie.",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "RU",
+        "iso_639_1": "ru",
+        "name": "Pусский",
+        "english_name": "Russian",
+        "data": {
+          "name": "Люпен",
+          "overview": "Ассан Диоп ещё в детстве прочитал книгу о приключениях грабителя Арсена Люпена и теперь собирается обчистить Лувр. Он сделает это красиво - во время аукциона, где выставляется дорогое колье. Но дело не только в деньгах: это месть богатому семейству, из-за которого 25 лет назад отца Диопа незаслуженно осудили за преступление.",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "NL",
+        "iso_639_1": "nl",
+        "name": "Nederlands",
+        "english_name": "Dutch",
+        "data": {
+          "name": "",
+          "overview": "Toen Assane Diop nog maar een tiener was werd zijn vader beschuldigd van een misdaad die hij niet gepleegd had. Zijn vader stierf en vijfentwintig jaar later is het tijd om wraak te nemen. Nu is Lupin een charmante inbreker die zijn talenten graag inzet om gestolen sieraden van vrouwen terug te vinden. Voor deze heldendaden zet hij veel op het spel. De crimineel sluipt namelijk het Louvre binnen voor een groot misdrijf. Of hij de grote klus geklaard krijgt is echter nog maar de vraag.",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "ES",
+        "iso_639_1": "es",
+        "name": "Español",
+        "english_name": "Spanish",
+        "data": {
+          "name": "",
+          "overview": "Inspirado por las aventuras de Arsène Lupin, el ladrón de guante blanco Assane Diop se propone vengar la injusticia sufrida por su padre a manos de una familia rica.",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "PL",
+        "iso_639_1": "pl",
+        "name": "Polski",
+        "english_name": "Polish",
+        "data": {
+          "name": "",
+          "overview": "Zainspirowany przygodami Arsène’a Lupina złodziej gentleman Assane Diop obmyśla zemstę na zamożnej rodzinie, która wyrządziła niesprawiedliwość jego ojcu.",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "CN",
+        "iso_639_1": "zh",
+        "name": "普通话",
+        "english_name": "Mandarin",
+        "data": {
+          "name": "",
+          "overview": "在阿桑·迪奥普十几岁的时候，他的父亲因含冤入狱而离开人世，此后他的生活发生了翻天覆地的变化。25年后，阿桑受到“怪盗绅士亚森·罗宾”的启发，决心为父报仇。",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "TW",
+        "iso_639_1": "zh",
+        "name": "普通话",
+        "english_name": "Mandarin",
+        "data": {
+          "name": "亞森·羅蘋",
+          "overview": "本劇靈感來自亞森·羅蘋的精采冒險，怪盜紳士亞森·迪歐籌劃為父報仇大計，要向一個富有的家族討回公道。",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "UA",
+        "iso_639_1": "uk",
+        "name": "Український",
+        "english_name": "Ukrainian",
+        "data": {
+          "name": "Люпен",
+          "overview": "Натхненний пригодами Арсена Люпена, благородний грабіжник Ассан Діоп вирішує помститися за свого батька, життя якого безкарно зруйнувала одна заможна родина.",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "CA",
+        "iso_639_1": "fr",
+        "name": "Français",
+        "english_name": "French",
+        "data": {
+          "name": "",
+          "overview": "Inspiré par les aventures d'Arsène Lupin, le gentleman cambrioleur Assane Diop entreprend de venger son père pour une injustice infligée par une famille bien nantie.",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "IL",
+        "iso_639_1": "he",
+        "name": "עִבְרִית",
+        "english_name": "Hebrew",
+        "data": {
+          "name": "לופן",
+          "overview": "הגנב הג'נטלמני אסאן דיופ שואב השראה מהרפתקאותיו של ארסן לופן, ויוצא להתנקם במשפחה העשירה שאחראית למות אביו.",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "VN",
+        "iso_639_1": "vi",
+        "name": "Tiếng Việt",
+        "english_name": "Vietnamese",
+        "data": {
+          "name": "",
+          "overview": "Lấy cảm hứng từ những cuộc phiêu lưu của Arsène Lupin, tên trộm lịch lãm Assane Diop tiến hành trả thù một gia đình giàu có để đòi lại công lý cho cha.",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "MX",
+        "iso_639_1": "es",
+        "name": "Español",
+        "english_name": "Spanish",
+        "data": {
+          "name": "",
+          "overview": "Inspirado en las aventuras de Arsène Lupin, el caballeroso ladrón Assane Diop se propone vengar a su padre de las injusticias sufridas a manos de una familia adinerada.",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "TH",
+        "iso_639_1": "th",
+        "name": "ภาษาไทย",
+        "english_name": "Thai",
+        "data": {
+          "name": "จอมโจรลูแปง",
+          "overview": "อัสซาน จ็อปผู้ได้รับแรงบันดาลใจจากวีรกรรมของสุภาพบุรุษจอมโจรอาร์แซน ลูแปง ตั้งใจแก้แค้นให้พ่อที่ได้รับความอยุติธรรมจากครอบครัวที่มั่งคั่ง",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "GR",
+        "iso_639_1": "el",
+        "name": "ελληνικά",
+        "english_name": "Greek",
+        "data": {
+          "name": "Λουπέν",
+          "overview": "Από τις περιπέτειες του Αρσέν Λουπέν, ο ευγενής λωποδύτης Ασάν Ντιόπ θέλει να πάρει εκδίκηση για τον πατέρα του για μια αδικία που προκάλεσε μια πλούσια οικογένεια.",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "JP",
+        "iso_639_1": "ja",
+        "name": "日本語",
+        "english_name": "Japanese",
+        "data": {
+          "name": "Lupin/ルパン",
+          "overview": "父を陥れた裕福な一家への報復に乗り出したアサン・ディオプ。怪盗紳士アルセーヌ・ルパンのごとく、あくまでもスマートに計画を実行していく。",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "SA",
+        "iso_639_1": "ar",
+        "name": "العربية",
+        "english_name": "Arabic",
+        "data": {
+          "name": "لوبين",
+          "overview": "متأثّرًا بأسلوب مغامرات \"أرسين لوبين\" ومهارته، ينطلق اللصّ النبيل \"أسان ديوب\" في مسعاه للانتقام من عائلة ثريّة ألحقت بوالده الضرر والظلم.",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "LT",
+        "iso_639_1": "lt",
+        "name": "Lietuvių",
+        "english_name": "Lithuanian",
+        "data": {
+          "name": "Lupenas",
+          "overview": "Įkvėptas Arsenijaus Lupeno nuotykių, ponas vagis Asanas Diopas siekia atkeršyti turtuolių šeimai už neteisingumą prieš jo tėvą.",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "BG",
+        "iso_639_1": "bg",
+        "name": "български език",
+        "english_name": "Bulgarian",
+        "data": {
+          "name": "Люпен",
+          "overview": "Животът на Асан Диоп се преобръща, когато баща му умира, след като е обвинен в престъпление, което не е извършил. 25 години по-късно Асан ще използва „Арсен Люпен“ като свое вдъхновение, за да отмъсти за баща си.",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "SK",
+        "iso_639_1": "sk",
+        "name": "Slovenčina",
+        "english_name": "Slovak",
+        "data": {
+          "name": "",
+          "overview": "Zlodej gentleman Assane Diop, inšpirovaný dobrodružstvami Arsèna Lupina, sa vydáva pomstiť svojho otca za nespravodlivosti, ktoré mu spôsobila bohatá rodina.",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "HR",
+        "iso_639_1": "hr",
+        "name": "Hrvatski",
+        "english_name": "Croatian",
+        "data": {
+          "name": "",
+          "overview": "Nadahnut pustolovinama Arsènea Lupina, lopov džentlmen Assane Diop kreće u osvetnički pohod zbog nepravde koju je njegovu ocu nanijela imućna obitelj.",
+          "homepage": "",
+          "tagline": "Profesionalni lopov kreće u osvetnički pohod kako bi osvetio oca"
+        }
+      },
+      {
+        "iso_3166_1": "SE",
+        "iso_639_1": "sv",
+        "name": "svenska",
+        "english_name": "Swedish",
+        "data": {
+          "name": "",
+          "overview": "Med inspiration från gentlemannatjuven Arsène Lupin börjar Assane Diop planera sin hämnd på den rika familjen som begick en stor oförrätt mot hans pappa.",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "ID",
+        "iso_639_1": "id",
+        "name": "Bahasa indonesia",
+        "english_name": "Indonesian",
+        "data": {
+          "name": "",
+          "overview": "Terinspirasi petualangan Arsène Lupin, Assane Diop, sang pencuri karismatik, bertekad membalaskan dendam ayahnya atas ketidakadilan yang ditimbulkan sebuah keluarga kaya.",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "RS",
+        "iso_639_1": "sr",
+        "name": "Srpski",
+        "english_name": "Serbian",
+        "data": {
+          "name": "Лупин",
+          "overview": "Инспирисан авантурама Арсена Лупена, лопов господин Асан Диоп креће да освети свог оца за неправду коју је нанела богата породица.",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "GE",
+        "iso_639_1": "ka",
+        "name": "ქართული",
+        "english_name": "Georgian",
+        "data": {
+          "name": "ლუპენი",
+          "overview": "ქურდი, ბავშვობაში ნაჩუქარი წიგნის გმირის, ვირტუოზი ჯენტლმენი ქურდის, არსენ ლუპენის სახელით ბრუნდება, რომელიც ახლა წიგნს შთაგონების წყაროდ იყენებს, და მამის სიკვდილის გამო შურისძიებას ცდილობს.",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "IR",
+        "iso_639_1": "fa",
+        "name": "فارسی",
+        "english_name": "Persian",
+        "data": {
+          "name": "لویپن",
+          "overview": "با الهام از ماجراهای آرسن لوپین، دزد لوطی آسان دیوپ تصمیم می‌گیرد تا انتقام پدرش را به‌خاطر بی‌عدالتی که توسط یک خانواده ثروتمند تحمیل شده است، بگیرد.",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "HK",
+        "iso_639_1": "zh",
+        "name": "普通话",
+        "english_name": "Mandarin",
+        "data": {
+          "name": "怪盜羅蘋",
+          "overview": "本劇靈感來自亞森·羅蘋的精採冒險，怪盜紳士亞森·迪歐籌劃為父報仇大計，要向一個富有的家族討回公道。",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "SI",
+        "iso_639_1": "sl",
+        "name": "Slovenščina",
+        "english_name": "Slovenian",
+        "data": {
+          "name": "Lupin",
+          "overview": "Dogajanje je postavljeno v sodobni Pariz, kjer spremljamo gentlemanskega lopova Assana Diopa v iskanju pravice, skozi retrospektive pa postopoma odkrivamo njegovo zgodovino, razmerja in predvsem motivacijo za dejanja v sedanjosti. Še v najstniških letih so njegovega očeta Babakarja Diopa obsodili kraje dragocene ogrlice, zaradi česar si je v zaporu vzel življenje; v spomin nanj je mlademu Assanu ostala zgolj Leblancova kriminalka, iz katere je kmalu začel črpati navdih za svoj 'poklic'.",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "MY",
+        "iso_639_1": "ms",
+        "name": "Bahasa melayu",
+        "english_name": "Malay",
+        "data": {
+          "name": "",
+          "overview": "Diinspirasikan oleh pengembaraan Arsène Lupin, pencuri berbudi bahasa Assane Diop mahu menuntut bela terhadap keluarga kaya kerana bersikap tidak adil terhadap ayahnya.",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "IN",
+        "iso_639_1": "hi",
+        "name": "हिन्दी",
+        "english_name": "Hindi",
+        "data": {
+          "name": "लूपां",
+          "overview": "आर्सेन ल्यूपिन के कारनामों से प्रेरित, जेंटलमैन चोर असान डिऑप अपने पिता पर एक अमीर परिवार द्वारा किए गए अन्याय का बदला लेने निकल पड़ता है.",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "RO",
+        "iso_639_1": "ro",
+        "name": "Română",
+        "english_name": "Romanian",
+        "data": {
+          "name": "",
+          "overview": "Inspirat de aventurile lui Arsène Lupin, hoțul gentilom Assane Diop vrea să-și răzbune tatăl, victima unei nedreptăți provocate de o familie înstărită.",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "SG",
+        "iso_639_1": "zh",
+        "name": "普通话",
+        "english_name": "Mandarin",
+        "data": {
+          "name": "绅士怪盗",
+          "overview": "本剧以亚森·罗宾的冒险经历为灵感，讲述了绅士怪盗阿桑·迪奥普因父亲的冤屈而向一个富有家族展开复仇的故事。",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "AE",
+        "iso_639_1": "ar",
+        "name": "العربية",
+        "english_name": "Arabic",
+        "data": {
+          "name": "لوبين",
+          "overview": "متأثّرًا بأسلوب مغامرات \"أرسين لوبين\" ومهارته، ينطلق اللصّ النبيل \"أسان ديوب\" في مسعاه للانتقام من عائلة ثريّة ألحقت بوالده الضرر والظلم.",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "FI",
+        "iso_639_1": "fi",
+        "name": "suomi",
+        "english_name": "Finnish",
+        "data": {
+          "name": "",
+          "overview": "Herrasmiesvaras Arsène Lupinin seikkailujen innoittamana Assane Diop päättää kostaa isänsä kokeman vääryyden sen aiheuttaneelle varakkaalle suvulle.",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "BE",
+        "iso_639_1": "nl",
+        "name": "Nederlands",
+        "english_name": "Dutch",
+        "data": {
+          "name": "",
+          "overview": "",
+          "homepage": "",
+          "tagline": ""
+        }
+      },
+      {
+        "iso_3166_1": "ES",
+        "iso_639_1": "ca",
+        "name": "Català",
+        "english_name": "Catalan",
+        "data": {
+          "name": "",
+          "overview": "Inspirat per les aventures d'Arsène Lupin, el lladre de guant blanc Assane Diop es proposa venjar la injustícia patida pel seu pare a les mans d'una família rica.",
+          "homepage": "",
+          "tagline": ""
+        }
+      }
+    ]
   }
 }

--- a/tmdb-api/src/jvmTest/resources/tmdb3/tv/tv_season_63333_season_1.json
+++ b/tmdb-api/src/jvmTest/resources/tmdb3/tv/tv_season_63333_season_1.json
@@ -2311,5 +2311,409 @@
     },
     "videos": {
         "results": []
+    },
+    "translations": {
+        "translations": [
+            {
+                "iso_3166_1": "US",
+                "iso_639_1": "en",
+                "name": "English",
+                "english_name": "English",
+                "data": {
+                    "name": "",
+                    "overview": "In Season 1, young Saxon noble Uhtred transforms into a warrior and seeks to regain the lands annexed by his cunning uncle."
+                }
+            },
+            {
+                "iso_3166_1": "FR",
+                "iso_639_1": "fr",
+                "name": "Français",
+                "english_name": "French",
+                "data": {
+                    "name": "",
+                    "overview": "Au cours de la saison 1, le jeune et noble Saxon Uhtred aux mœurs vikings devient un guerrier et s'efforce de récupérer les terres dont son oncle félon l'a dépossédé."
+                }
+            },
+            {
+                "iso_3166_1": "GR",
+                "iso_639_1": "el",
+                "name": "ελληνικά",
+                "english_name": "Greek",
+                "data": {
+                    "name": "",
+                    "overview": "Στην πρώτη σεζόν, ο νεαρός ευγενής Σάξονας Ούτρεντ μεταμορφώνεται σε πολεμιστή και επιδιώκει να πάρει πίσω τη γη που σφετερίστηκε ο πανούργος θείος του."
+                }
+            },
+            {
+                "iso_3166_1": "RU",
+                "iso_639_1": "ru",
+                "name": "Pусский",
+                "english_name": "Russian",
+                "data": {
+                    "name": "",
+                    "overview": "В первом сезоне молодой саксонский дворянин Утред надевает доспехи воина, чтобы отвоевать земли, захваченные его коварным дядей."
+                }
+            },
+            {
+                "iso_3166_1": "ES",
+                "iso_639_1": "es",
+                "name": "Español",
+                "english_name": "Spanish",
+                "data": {
+                    "name": "",
+                    "overview": "En la temporada 1, el joven noble sajón Uhtred se transforma en un guerrero y busca recuperar las tierras anexadas por su astuto tío."
+                }
+            },
+            {
+                "iso_3166_1": "CZ",
+                "iso_639_1": "cs",
+                "name": "Český",
+                "english_name": "Czech",
+                "data": {
+                    "name": "1. řada",
+                    "overview": "V první řadě se mladý saský šlechtic Uhtred promění ve válečníka, který se snaží získat zpět své území usurpované mazaným strýcem."
+                }
+            },
+            {
+                "iso_3166_1": "ID",
+                "iso_639_1": "id",
+                "name": "Bahasa indonesia",
+                "english_name": "Indonesian",
+                "data": {
+                    "name": "",
+                    "overview": ""
+                }
+            },
+            {
+                "iso_3166_1": "TR",
+                "iso_639_1": "tr",
+                "name": "Türkçe",
+                "english_name": "Turkish",
+                "data": {
+                    "name": "",
+                    "overview": "Birinci sezonda genç Sakson soylusu Uhtred bir savaşçıya dönüşür ve kurnaz amcası tarafından ele geçirilen toprakları geri kazanmaya çalışır."
+                }
+            },
+            {
+                "iso_3166_1": "PT",
+                "iso_639_1": "pt",
+                "name": "Português",
+                "english_name": "Portuguese",
+                "data": {
+                    "name": "",
+                    "overview": "Na temporada 1, o jovem nobre saxão Uhtred transforma-se num guerreiro e procura recuperar os territórios anexados pelo seu manipulador tio."
+                }
+            },
+            {
+                "iso_3166_1": "DE",
+                "iso_639_1": "de",
+                "name": "Deutsch",
+                "english_name": "German",
+                "data": {
+                    "name": "",
+                    "overview": "The Last Kingdom – Staffel 1 basiert auf dem gleichnamigen Bestseller von Bernard Cornwell und erzählt die Geschichte von Uhtred, der als Junge von Wikingern entführt wurde und nun das Kind zweier Welten ist."
+                }
+            },
+            {
+                "iso_3166_1": "BS",
+                "iso_639_1": "bs",
+                "name": "Bosanski",
+                "english_name": "Bosnian",
+                "data": {
+                    "name": "",
+                    "overview": ""
+                }
+            },
+            {
+                "iso_3166_1": "RO",
+                "iso_639_1": "ro",
+                "name": "Română",
+                "english_name": "Romanian",
+                "data": {
+                    "name": "",
+                    "overview": ""
+                }
+            },
+            {
+                "iso_3166_1": "IL",
+                "iso_639_1": "he",
+                "name": "עִבְרִית",
+                "english_name": "Hebrew",
+                "data": {
+                    "name": "",
+                    "overview": "כשאלפרד הגדול מגן על ממלכתו מפני פולשים נורבגיים, אות'רד – שנולד סקסוני אך גדל בקרב ויקינגים – מבקש לתבוע את זכות אבותיו."
+                }
+            },
+            {
+                "iso_3166_1": "BR",
+                "iso_639_1": "pt",
+                "name": "Português",
+                "english_name": "Portuguese",
+                "data": {
+                    "name": "",
+                    "overview": ""
+                }
+            },
+            {
+                "iso_3166_1": "UA",
+                "iso_639_1": "uk",
+                "name": "Український",
+                "english_name": "Ukrainian",
+                "data": {
+                    "name": "Сезон 1",
+                    "overview": ""
+                }
+            },
+            {
+                "iso_3166_1": "IT",
+                "iso_639_1": "it",
+                "name": "Italiano",
+                "english_name": "Italian",
+                "data": {
+                    "name": "",
+                    "overview": "Nella prima stagione, il giovane nobile sassone Uhtred diventa un vero guerriero e cerca di riconquistare le terre annesse dallo scaltro zio."
+                }
+            },
+            {
+                "iso_3166_1": "DK",
+                "iso_639_1": "da",
+                "name": "Dansk",
+                "english_name": "Danish",
+                "data": {
+                    "name": "",
+                    "overview": ""
+                }
+            },
+            {
+                "iso_3166_1": "NL",
+                "iso_639_1": "nl",
+                "name": "Nederlands",
+                "english_name": "Dutch",
+                "data": {
+                    "name": "",
+                    "overview": "De Saksische adellijke jongeling Uhtred wordt een krijgsman en tracht de gebieden die zijn geannexeerd door zijn listige oom te heroveren."
+                }
+            },
+            {
+                "iso_3166_1": "ES",
+                "iso_639_1": "ca",
+                "name": "Català",
+                "english_name": "Catalan",
+                "data": {
+                    "name": "",
+                    "overview": ""
+                }
+            },
+            {
+                "iso_3166_1": "SE",
+                "iso_639_1": "sv",
+                "name": "svenska",
+                "english_name": "Swedish",
+                "data": {
+                    "name": "",
+                    "overview": ""
+                }
+            },
+            {
+                "iso_3166_1": "CN",
+                "iso_639_1": "zh",
+                "name": "普通话",
+                "english_name": "Mandarin",
+                "data": {
+                    "name": "",
+                    "overview": ""
+                }
+            },
+            {
+                "iso_3166_1": "KR",
+                "iso_639_1": "ko",
+                "name": "한국어/조선말",
+                "english_name": "Korean",
+                "data": {
+                    "name": "",
+                    "overview": "바이킹의 손에 친부를 잃고 바이킹의 아들로 키워진 우트레드. 또 한 번의 참사로 양부까지 잃자, 본격적으로 전사의 길을 걷기 시작한다. 아비의 원수를 갚고, 빼앗긴 땅을 찾아라. 지금부터는 이것이 그가 사는 이유다."
+                }
+            },
+            {
+                "iso_3166_1": "PL",
+                "iso_639_1": "pl",
+                "name": "Polski",
+                "english_name": "Polish",
+                "data": {
+                    "name": "",
+                    "overview": "Młody saski arystokrata Uhtred przeobraża się w wojownika i przymierza się do odzyskania ziem zagarniętych przez swojego chciwego wuja."
+                }
+            },
+            {
+                "iso_3166_1": "BG",
+                "iso_639_1": "bg",
+                "name": "български език",
+                "english_name": "Bulgarian",
+                "data": {
+                    "name": "",
+                    "overview": ""
+                }
+            },
+            {
+                "iso_3166_1": "HU",
+                "iso_639_1": "hu",
+                "name": "Magyar",
+                "english_name": "Hungarian",
+                "data": {
+                    "name": "",
+                    "overview": ""
+                }
+            },
+            {
+                "iso_3166_1": "TW",
+                "iso_639_1": "zh",
+                "name": "普通话",
+                "english_name": "Mandarin",
+                "data": {
+                    "name": "",
+                    "overview": "在第 1 季中，年輕的撒克遜貴族烏特雷德成為戰士，力圖奪回被狡猾的叔叔強佔的土地。"
+                }
+            },
+            {
+                "iso_3166_1": "LT",
+                "iso_639_1": "lt",
+                "name": "Lietuvių",
+                "english_name": "Lithuanian",
+                "data": {
+                    "name": "",
+                    "overview": ""
+                }
+            },
+            {
+                "iso_3166_1": "IR",
+                "iso_639_1": "fa",
+                "name": "فارسی",
+                "english_name": "Persian",
+                "data": {
+                    "name": "",
+                    "overview": ""
+                }
+            },
+            {
+                "iso_3166_1": "MX",
+                "iso_639_1": "es",
+                "name": "Español",
+                "english_name": "Spanish",
+                "data": {
+                    "name": "",
+                    "overview": ""
+                }
+            },
+            {
+                "iso_3166_1": "JP",
+                "iso_639_1": "ja",
+                "name": "日本語",
+                "english_name": "Japanese",
+                "data": {
+                    "name": "",
+                    "overview": ""
+                }
+            },
+            {
+                "iso_3166_1": "SA",
+                "iso_639_1": "ar",
+                "name": "العربية",
+                "english_name": "Arabic",
+                "data": {
+                    "name": "",
+                    "overview": "في الموسم الاول ، يتحول الشاب الساكسوني النبيل أوتريد إلى محارب ويسعى لاستعادة الأراضي التي ضمها عمه الماكر."
+                }
+            },
+            {
+                "iso_3166_1": "TH",
+                "iso_639_1": "th",
+                "name": "ภาษาไทย",
+                "english_name": "Thai",
+                "data": {
+                    "name": "",
+                    "overview": ""
+                }
+            },
+            {
+                "iso_3166_1": "RS",
+                "iso_639_1": "sr",
+                "name": "Srpski",
+                "english_name": "Serbian",
+                "data": {
+                    "name": "",
+                    "overview": ""
+                }
+            },
+            {
+                "iso_3166_1": "SK",
+                "iso_639_1": "sk",
+                "name": "Slovenčina",
+                "english_name": "Slovak",
+                "data": {
+                    "name": "",
+                    "overview": ""
+                }
+            },
+            {
+                "iso_3166_1": "CA",
+                "iso_639_1": "fr",
+                "name": "Français",
+                "english_name": "French",
+                "data": {
+                    "name": "",
+                    "overview": "À la fin du IXème siècle, ce qu’on appelle l’Angleterre aujourd’hui est séparée en plusieurs royaumes. Les terres anglo-saxonnes sont attaquées et régies par les Danois. Uhtred est le fils orphelin d’un noble saxon. Kidnappé par les Scandinaves et élevé parmi eux, il devra sans cesse choisir entre le royaume de ses origines et le peuple qui l’a vu grandir."
+                }
+            },
+            {
+                "iso_3166_1": "VN",
+                "iso_639_1": "vi",
+                "name": "Tiếng Việt",
+                "english_name": "Vietnamese",
+                "data": {
+                    "name": "Mùa 1",
+                    "overview": "Trong mùa đầu, chàng quý tộc Saxon trẻ Uhtred mà nay đã trở thành chiến binh lên đường giành lại những vùng đất đã bị nẫng tay trên bởi ông chú mưu mô."
+                }
+            },
+            {
+                "iso_3166_1": "GE",
+                "iso_639_1": "ka",
+                "name": "ქართული",
+                "english_name": "Georgian",
+                "data": {
+                    "name": "",
+                    "overview": ""
+                }
+            },
+            {
+                "iso_3166_1": "MY",
+                "iso_639_1": "my",
+                "name": "",
+                "english_name": "Burmese",
+                "data": {
+                    "name": "",
+                    "overview": ""
+                }
+            },
+            {
+                "iso_3166_1": "FI",
+                "iso_639_1": "fi",
+                "name": "suomi",
+                "english_name": "Finnish",
+                "data": {
+                    "name": "",
+                    "overview": ""
+                }
+            },
+            {
+                "iso_3166_1": "HK",
+                "iso_639_1": "zh",
+                "name": "普通话",
+                "english_name": "Mandarin",
+                "data": {
+                    "name": "",
+                    "overview": "在第 1 季中，年輕的撒克遜貴族烏特雷德成為戰士，力圖奪回被狡猾的叔叔強佔的土地。"
+                }
+            }
+        ]
     }
 }


### PR DESCRIPTION
Details model classes are missing a `translations` key, so this information was impossible to obtain via the `append_to_response` parameter.

Additionally, the standalone calls to the `<resource>/translations` API (via `getTranslations` functions) are not modelling translations data which is returned by the API, so I've made the class generic so that it can be reused across different entity types and implemented the correct data object for each one. In order to do this, I've had to make `id` nullable, in the same vein that makes `TmdbImages.id` nullable as well. There's also a convenient type alias to avoid having to deal with generics.

I've updated test resources with `translations` keys obtained directly from the API. To do this I've created a very basic bash function, adding here as reference for future use:
```bash
add_or_update_translations() {
  api_path="$1"
  file_name="$2"
  indent="$3"
  
  api_result=$(curl -s --request GET --url "https://api.themoviedb.org/3/$api_path?append_to_response=translations&language=en-US" --header "Authorization: Bearer $BEARER_TOKEN" --header 'accept: application/json')
  translations_only=$(echo "$api_result" | jq 'with_entries(select([.key] | inside(["translations"])))')
  old_with_translations=$(jq ". += $translations_only" "$file_name")
  echo "$old_with_translations" | jq . --indent "$indent" > "$file_name"
  echo "Done!"
}
```

Then called it like this to update the various files:
```bash
add_or_update_translations "movie/10140" "movie/movie_details_10140.json" 2
add_or_update_translations "person/11701" "person/person_details_11701_all_responses.json" 4
add_or_update_translations "tv/96677" "tv/tv_details_96677.json" 2
add_or_update_translations "tv/63333/season/1" "tv/tv_season_63333_season_1.json" 4
add_or_update_translations "tv/96677/season/1/episode/1" "tv/episode/tv_details_96677_s1e1.json" 2
```
