### PR TITLE
Add keywords, recommendations, and alt_titles to `AppendResponse`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,6 @@ ij_kotlin_allow_trailing_comma_on_call_site = true
 
 [*.{yml,yaml}]
 indent_size = 2
+
+[*.json]
+indent_size = 2

--- a/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/model/TmdbKeywordsModel.kt
+++ b/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/model/TmdbKeywordsModel.kt
@@ -22,3 +22,8 @@ data class TmdbKeywordPageResult(
     @SerialName("total_results") override val totalResults: Int,
     @SerialName("total_pages") override val totalPages: Int
 ) : TmdbPageResult<TmdbKeywordDetail>
+
+@Serializable
+data class TmdbKeywords(
+    @SerialName("keywords") val keywords: List<TmdbKeyword> = emptyList()
+)

--- a/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/model/TmdbModel.kt
+++ b/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/model/TmdbModel.kt
@@ -26,7 +26,10 @@ enum class AppendResponse(val value: String) {
     CONTENT_RATING("content_ratings"),
     MOVIE_CREDITS("movie_credits"),
     TV_CREDITS("tv_credits"),
-    WATCH_PROVIDERS("watch/providers");
+    WATCH_PROVIDERS("watch/providers"),
+    KEYWORDS("keywords"),
+    RECOMMENDATIONS("recommendations"),
+    ALTERNATIVE_TITLES("alternative_titles");
 
     companion object {
         fun build(appendResponses: Iterable<AppendResponse>) = appendResponses.joinToString(",") { it.value }

--- a/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/model/TmdbMovieModel.kt
+++ b/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/model/TmdbMovieModel.kt
@@ -122,6 +122,9 @@ data class TmdbMovieDetail(
     @SerialName("reviews") val reviews: TmdbResult<TmdbReview>? = null,
     @SerialName("images") val images: TmdbImages? = null,
     @SerialName("translations") val translations: TmdbMovieTranslations? = null,
+    @SerialName("keywords") val keywords: TmdbKeywords? = null,
+    @SerialName("recommendations") val recommendations: TmdbResult<TmdbMovie>? = null,
+    @SerialName("alternative_titles") val alternativeTitles: TmdbAlternativeTitlesResult? = null,
     @SerialName("belongs_to_collection") val belongsToCollection: TmdbBelongsToCollection? = null,
 ) : TmdbRatingItem {
 
@@ -167,6 +170,11 @@ data class TmdbBelongsToCollection(
     @SerialName("name") val name: String,
     @SerialName("backdrop_path") val backdropPath: String? = null,
     @SerialName("parts") val parts: List<TmdbMovie> = emptyList()
+)
+
+@Serializable
+data class TmdbAlternativeTitlesResult(
+    @SerialName("titles") val titles: List<TmdbAlternativeTitle> = emptyList()
 )
 
 @Serializable

--- a/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/model/TmdbShowModel.kt
+++ b/tmdb-api/src/commonMain/kotlin/app/moviebase/tmdb/model/TmdbShowModel.kt
@@ -138,6 +138,9 @@ data class TmdbShowDetail(
     @SerialName("reviews") val reviews: TmdbResult<TmdbReview>? = null,
     @SerialName("created_by") val createdBy: List<TmdbShowCreatedBy>? = null,
     @SerialName("translations") val translations: TmdbShowTranslations? = null,
+    @SerialName("keywords") val keywords: TmdbResult<TmdbKeyword>? = null,
+    @SerialName("recommendations") val recommendations: TmdbResult<TmdbShow>? = null,
+    @SerialName("alternative_titles") val alternativeTitles: TmdbResult<TmdbAlternativeTitle>? = null,
 ) : TmdbAnyItem, TmdbBackdropItem, TmdbPosterItem, TmdbRatingItem
 
 

--- a/tmdb-api/src/jvmTest/kotlin/app/moviebase/tmdb/api/TmdbMoviesApiTest.kt
+++ b/tmdb-api/src/jvmTest/kotlin/app/moviebase/tmdb/api/TmdbMoviesApiTest.kt
@@ -2,6 +2,8 @@ package app.moviebase.tmdb.api
 
 import app.moviebase.tmdb.core.mockHttpClient
 import app.moviebase.tmdb.model.AppendResponse
+import app.moviebase.tmdb.model.TmdbAlternativeTitle
+import app.moviebase.tmdb.model.TmdbKeyword
 import app.moviebase.tmdb.model.TmdbReleaseType
 import app.moviebase.tmdb.model.TmdbVideoType
 import app.moviebase.tmdb.model.getCertification
@@ -17,7 +19,7 @@ class TmdbMoviesApiTest {
     val client = mockHttpClient(
         version = 3,
         responses = mapOf(
-            "movie/10140?language=en-US&append_to_response=images,external_ids,videos,release_dates,credits,reviews,content_ratings,watch/providers,translations"
+            "movie/10140?language=en-US&append_to_response=images,external_ids,videos,release_dates,credits,reviews,content_ratings,watch/providers,translations,keywords,recommendations,alternative_titles"
                 to "movie/movie_details_10140.json",
             "movie/10140/images?language=en"
                 to "movie/movie_images_10140.json",
@@ -59,6 +61,9 @@ class TmdbMoviesApiTest {
                 AppendResponse.CONTENT_RATING,
                 AppendResponse.WATCH_PROVIDERS,
                 AppendResponse.TRANSLATIONS,
+                AppendResponse.KEYWORDS,
+                AppendResponse.RECOMMENDATIONS,
+                AppendResponse.ALTERNATIVE_TITLES
             )
         )
 
@@ -81,6 +86,19 @@ class TmdbMoviesApiTest {
         assertThat(spanishTranslation.data.title).isEqualTo("Las crónicas de Narnia: La travesía del viajero del alba")
         assertThat(spanishTranslation.data.tagline).isEqualTo("Emprende el viaje. Vive la aventura. Descubre Narnia como nunca antes la habías visto.")
         assertThat(spanishTranslation.data.runtime).isEqualTo(113)
+
+        val keywords = movieDetails.keywords!!.keywords
+        assertThat(keywords).hasSize(19)
+        assertThat(keywords.first()).isEqualTo(TmdbKeyword(818, "based on novel or book"))
+        assertThat(keywords.last()).isEqualTo(TmdbKeyword(325762, "adoring"))
+
+        val recommendations = movieDetails.recommendations!!.results
+        assertThat(recommendations).hasSize(20)
+
+        val alternativeTitles = movieDetails.alternativeTitles!!.titles
+        assertThat(alternativeTitles).hasSize(19)
+        assertThat(alternativeTitles.first()).isEqualTo(TmdbAlternativeTitle("US", "The Chronicles of Narnia - The Voyage of the Dawn Treader - 3D", "3D version"))
+        assertThat(alternativeTitles.last()).isEqualTo(TmdbAlternativeTitle("RU", "Хроники Нарнии 3", ""))
     }
 
     @Test

--- a/tmdb-api/src/jvmTest/kotlin/app/moviebase/tmdb/api/TmdbShowsApiTest.kt
+++ b/tmdb-api/src/jvmTest/kotlin/app/moviebase/tmdb/api/TmdbShowsApiTest.kt
@@ -3,6 +3,8 @@ package app.moviebase.tmdb.api
 import app.moviebase.tmdb.model.AppendResponse
 import app.moviebase.tmdb.model.TmdbVideoType
 import app.moviebase.tmdb.core.mockHttpClient
+import app.moviebase.tmdb.model.TmdbAlternativeTitle
+import app.moviebase.tmdb.model.TmdbKeyword
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Nested
@@ -13,7 +15,7 @@ class TmdbShowsApiTest {
     val client = mockHttpClient(
         version = 3,
         responses = mapOf(
-            "tv/96677?language=en-US&append_to_response=external_ids,videos,credits,aggregate_credits,reviews,content_ratings,watch/providers,translations"
+            "tv/96677?language=en-US&append_to_response=external_ids,videos,credits,aggregate_credits,reviews,content_ratings,watch/providers,translations,keywords,recommendations,alternative_titles"
                 to "tv/tv_details_96677.json",
             "tv/96677?language=de-DE&append_to_response=images" to "tv/tv_details_96677_with_images.json",
             "tv/96677/images?language=en&include_image_language=en,null" to "tv/tv_images_96677.json",
@@ -41,7 +43,10 @@ class TmdbShowsApiTest {
                     AppendResponse.REVIEWS,
                     AppendResponse.CONTENT_RATING,
                     AppendResponse.WATCH_PROVIDERS,
-                    AppendResponse.TRANSLATIONS
+                    AppendResponse.TRANSLATIONS,
+                    AppendResponse.KEYWORDS,
+                    AppendResponse.RECOMMENDATIONS,
+                    AppendResponse.ALTERNATIVE_TITLES
                 )
             )
 
@@ -68,6 +73,19 @@ class TmdbShowsApiTest {
             assertThat(lithuanianTranslation).isNotNull()
             assertThat(lithuanianTranslation.data.name).isEqualTo("Lupenas")
             assertThat(lithuanianTranslation.data.overview).isEqualTo("Įkvėptas Arsenijaus Lupeno nuotykių, ponas vagis Asanas Diopas siekia atkeršyti turtuolių šeimai už neteisingumą prieš jo tėvą.")
+
+            val keywords = showDetails.keywords!!.results
+            assertThat(keywords).hasSize(14)
+            assertThat(keywords.first()).isEqualTo(TmdbKeyword(90, "paris, france"))
+            assertThat(keywords.last()).isEqualTo(TmdbKeyword(322496, "action"))
+
+            val recommendations = showDetails.recommendations!!.results
+            assertThat(recommendations).hasSize(20)
+
+            val alternativeTitles = showDetails.alternativeTitles!!.results
+            assertThat(alternativeTitles).hasSize(8)
+            assertThat(alternativeTitles.first()).isEqualTo(TmdbAlternativeTitle("CN", "绅士怪盗", ""))
+            assertThat(alternativeTitles.last()).isEqualTo(TmdbAlternativeTitle("UA", "Арсен Люпен", ""))
         }
 
         @Test

--- a/tmdb-api/src/jvmTest/resources/tmdb3/movie/movie_details_10140.json
+++ b/tmdb-api/src/jvmTest/resources/tmdb3/movie/movie_details_10140.json
@@ -5638,5 +5638,619 @@
         }
       }
     ]
+  },
+  "keywords": {
+    "keywords": [
+      {
+        "id": 818,
+        "name": "based on novel or book"
+      },
+      {
+        "id": 2343,
+        "name": "magic"
+      },
+      {
+        "id": 2043,
+        "name": "lion"
+      },
+      {
+        "id": 11477,
+        "name": "anthropomorphism"
+      },
+      {
+        "id": 12554,
+        "name": "dragon"
+      },
+      {
+        "id": 13084,
+        "name": "king"
+      },
+      {
+        "id": 41538,
+        "name": "turns into animal"
+      },
+      {
+        "id": 170362,
+        "name": "fantasy world"
+      },
+      {
+        "id": 182772,
+        "name": "snowing"
+      },
+      {
+        "id": 188280,
+        "name": "sea voyage"
+      },
+      {
+        "id": 207372,
+        "name": "quest"
+      },
+      {
+        "id": 211227,
+        "name": "high fantasy"
+      },
+      {
+        "id": 237451,
+        "name": "isekai"
+      },
+      {
+        "id": 240119,
+        "name": "father son relationship"
+      },
+      {
+        "id": 240485,
+        "name": "brother sister relationship"
+      },
+      {
+        "id": 246466,
+        "name": "based on young adult novel"
+      },
+      {
+        "id": 251667,
+        "name": "anxious"
+      },
+      {
+        "id": 269233,
+        "name": "good versus evil"
+      },
+      {
+        "id": 325762,
+        "name": "adoring"
+      }
+    ]
+  },
+  "recommendations": {
+    "page": 1,
+    "results": [
+      {
+        "adult": false,
+        "backdrop_path": "/9pBv1BOSloAUgAkF0meJWdnbV4Q.jpg",
+        "id": 2454,
+        "title": "The Chronicles of Narnia: Prince Caspian",
+        "original_title": "The Chronicles of Narnia: Prince Caspian",
+        "overview": "One year after their incredible adventures in the Lion, the Witch and the Wardrobe, Peter, Edmund, Lucy and Susan Pevensie return to Narnia to aid a young prince whose life has been threatened by the evil King Miraz. Now, with the help of a colorful cast of new characters, including Trufflehunter the badger and Nikabrik the dwarf, the Pevensie clan embarks on an incredible quest to ensure that Narnia is returned to its rightful heir.",
+        "poster_path": "/qxz3WIyjZiSKUhaTIEJ3c1GcC9z.jpg",
+        "media_type": "movie",
+        "original_language": "en",
+        "genre_ids": [
+          12,
+          10751,
+          14
+        ],
+        "popularity": 8.134,
+        "release_date": "2008-05-15",
+        "video": false,
+        "vote_average": 6.63,
+        "vote_count": 6710
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/oiwc338EoBgS4sEI2ixAny4KQKg.jpg",
+        "id": 120,
+        "title": "The Lord of the Rings: The Fellowship of the Ring",
+        "original_title": "The Lord of the Rings: The Fellowship of the Ring",
+        "overview": "Young hobbit Frodo Baggins, after inheriting a mysterious ring from his uncle Bilbo, must leave his home in order to keep it from falling into the hands of its evil creator. Along the way, a fellowship is formed to protect the ringbearer and make sure that the ring arrives at its final destination: Mt. Doom, the only place where it can be destroyed.",
+        "poster_path": "/6oom5QYQ2yQTMJIbnvbkBL9cHo6.jpg",
+        "media_type": "movie",
+        "original_language": "en",
+        "genre_ids": [
+          12,
+          14,
+          28
+        ],
+        "popularity": 36.7334,
+        "release_date": "2001-12-18",
+        "video": false,
+        "vote_average": 8.429,
+        "vote_count": 27230
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/tuDhEdza074bA497bO9WFEPs6O6.jpg",
+        "id": 411,
+        "title": "The Chronicles of Narnia: The Lion, the Witch and the Wardrobe",
+        "original_title": "The Chronicles of Narnia: The Lion, the Witch and the Wardrobe",
+        "overview": "Siblings Lucy, Edmund, Susan and Peter step through a magical wardrobe and find the land of Narnia. There, they discover a charming, once peaceful kingdom that has been plunged into eternal winter by the evil White Witch, Jadis. Aided by the wise and magnificent lion, Aslan, the children lead Narnia into a spectacular, climactic battle to be free of the Witch's glacial powers forever.",
+        "poster_path": "/iREd0rNCjYdf5Ar0vfaW32yrkm.jpg",
+        "media_type": "movie",
+        "original_language": "en",
+        "genre_ids": [
+          12,
+          10751,
+          14
+        ],
+        "popularity": 18.9075,
+        "release_date": "2005-12-07",
+        "video": false,
+        "vote_average": 7.135,
+        "vote_count": 11397
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/cVfaHnjOOS5qX8z10qnBsslq2Oi.jpg",
+        "id": 8204,
+        "title": "The Spiderwick Chronicles",
+        "original_title": "The Spiderwick Chronicles",
+        "overview": "Upon moving into the run-down Spiderwick Estate with their mother, twin brothers Jared and Simon Grace, along with their sister Mallory, find themselves pulled into an alternate world full of faeries and other creatures.",
+        "poster_path": "/uN7MUMaCXfa8DbMMp61A8iXEcEG.jpg",
+        "media_type": "movie",
+        "original_language": "en",
+        "genre_ids": [
+          10751,
+          12,
+          14,
+          18
+        ],
+        "popularity": 5.3186,
+        "release_date": "2008-02-14",
+        "video": false,
+        "vote_average": 6.7,
+        "vote_count": 2810
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/hwPnxzIgQFfXl5zP0Yh8bViCMzf.jpg",
+        "id": 57158,
+        "title": "The Hobbit: The Desolation of Smaug",
+        "original_title": "The Hobbit: The Desolation of Smaug",
+        "overview": "The Dwarves, Bilbo and Gandalf have successfully escaped the Misty Mountains, and Bilbo has gained the One Ring. They all continue their journey to get their gold back from the Dragon, Smaug.",
+        "poster_path": "/xQYiXsheRCDBA39DOrmaw1aSpbk.jpg",
+        "media_type": "movie",
+        "original_language": "en",
+        "genre_ids": [
+          14,
+          12,
+          28
+        ],
+        "popularity": 12.0407,
+        "release_date": "2013-12-11",
+        "video": false,
+        "vote_average": 7.576,
+        "vote_count": 14055
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/kWYfW2Re0rUDE6IHhy4CRuKWeFr.jpg",
+        "id": 121,
+        "title": "The Lord of the Rings: The Two Towers",
+        "original_title": "The Lord of the Rings: The Two Towers",
+        "overview": "Frodo Baggins and the other members of the Fellowship continue on their sacred quest to destroy the One Ring--but on separate paths. Their destinies lie at two towers--Orthanc Tower in Isengard, where the corrupt wizard Saruman awaits, and Sauron's fortress at Barad-dur, deep within the dark lands of Mordor. Frodo and Sam are trekking to Mordor to destroy the One Ring of Power while Gimli, Legolas and Aragorn search for the orc-captured Merry and Pippin. All along, nefarious wizard Saruman awaits the Fellowship members at the Orthanc Tower in Isengard.",
+        "poster_path": "/5VTN0pR8gcqV3EPUHHfMGnJYN9L.jpg",
+        "media_type": "movie",
+        "original_language": "en",
+        "genre_ids": [
+          12,
+          14,
+          28
+        ],
+        "popularity": 23.2115,
+        "release_date": "2002-12-18",
+        "video": false,
+        "vote_average": 8.413,
+        "vote_count": 23626
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/nSecCfPlqAXtm1EOBmxSTNbn7eQ.jpg",
+        "id": 893345,
+        "title": "The Secret Kingdom",
+        "original_title": "The Secret Kingdom",
+        "overview": "Verity and Peter’s trip to the old family mansion takes a turn when the floor of their room suddenly gives way and they fall into an underground chamber where they are met by a civilization of creatures. The leader tells them that Peter's arrival was foretold as he’s the one who can use Great Clock of the Citadel to restart time and destroy the Shroud, a malevolent creature who feeds on fear itself...",
+        "poster_path": "/dteXMzVY53GBHUgrR7vigAartsP.jpg",
+        "media_type": "movie",
+        "original_language": "en",
+        "genre_ids": [
+          12,
+          10751,
+          14
+        ],
+        "popularity": 2.7849,
+        "release_date": "2023-04-27",
+        "video": false,
+        "vote_average": 6.3,
+        "vote_count": 76
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/79PNOxNXSe5e0bhEj11QJPlsdCN.jpg",
+        "id": 1087192,
+        "title": "How to Train Your Dragon",
+        "original_title": "How to Train Your Dragon",
+        "overview": "On the rugged isle of Berk, where Vikings and dragons have been bitter enemies for generations, Hiccup stands apart, defying centuries of tradition when he befriends Toothless, a feared Night Fury dragon. Their unlikely bond reveals the true nature of dragons, challenging the very foundations of Viking society.",
+        "poster_path": "/41dfWUWtg1kUZcJYe6Zk6ewxzMu.jpg",
+        "media_type": "movie",
+        "original_language": "en",
+        "genre_ids": [
+          14,
+          10751,
+          28,
+          12
+        ],
+        "popularity": 25.394,
+        "release_date": "2025-06-06",
+        "video": false,
+        "vote_average": 7.925,
+        "vote_count": 2690
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/fACoy2VWw9lz1UbqrgtbIcSYi5e.jpg",
+        "id": 266647,
+        "title": "Pan",
+        "original_title": "Pan",
+        "overview": "Living a bleak existence at a London orphanage, 12-year-old Peter finds himself whisked away to the fantastical world of Neverland. Adventure awaits as he meets new friend James Hook and the warrior Tiger Lily. They must band together to save Neverland from the ruthless pirate Blackbeard. Along the way, the rebellious and mischievous boy discovers his true destiny, becoming the hero forever known as Peter Pan.",
+        "poster_path": "/w8i0mZR7MEL7c3bXSsuYg7VJsew.jpg",
+        "media_type": "movie",
+        "original_language": "en",
+        "genre_ids": [
+          14,
+          12,
+          10751,
+          28
+        ],
+        "popularity": 5.6436,
+        "release_date": "2015-09-24",
+        "video": false,
+        "vote_average": 6,
+        "vote_count": 2826
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/3UbaCMmqOd7mca4Y5DOzY2ZVTyX.jpg",
+        "id": 122917,
+        "title": "The Hobbit: The Battle of the Five Armies",
+        "original_title": "The Hobbit: The Battle of the Five Armies",
+        "overview": "Following Smaug's attack on Laketown, Bilbo and the dwarves try to defend Erebor's mountain of treasure from others who claim it: the men of the ruined Laketown and the elves of Mirkwood. Meanwhile an army of Orcs led by Azog the Defiler is marching on Erebor, fueled by the rise of the dark lord Sauron. Dwarves, elves and men must unite, and the hope for Middle-Earth falls into Bilbo's hands.",
+        "poster_path": "/xT98tLqatZPQApyRmlPL12LtiWp.jpg",
+        "media_type": "movie",
+        "original_language": "en",
+        "genre_ids": [
+          28,
+          12,
+          14
+        ],
+        "popularity": 23.9265,
+        "release_date": "2014-12-10",
+        "video": false,
+        "vote_average": 7.332,
+        "vote_count": 15216
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/bcT8CaBIj086WVD7K529h78eujb.jpg",
+        "id": 508439,
+        "title": "Onward",
+        "original_title": "Onward",
+        "overview": "In a suburban fantasy world, two teenage elf brothers embark on an extraordinary quest to discover if there is still a little magic left out there.",
+        "poster_path": "/f4aul3FyD3jv3v4bul1IrkWZvzq.jpg",
+        "media_type": "movie",
+        "original_language": "en",
+        "genre_ids": [
+          10751,
+          35,
+          12,
+          16,
+          14
+        ],
+        "popularity": 9.0343,
+        "release_date": "2020-02-29",
+        "video": false,
+        "vote_average": 7.643,
+        "vote_count": 6513
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/h3KN24PrOheHVYs9ypuOIdFBEpX.jpg",
+        "id": 166428,
+        "title": "How to Train Your Dragon: The Hidden World",
+        "original_title": "How to Train Your Dragon: The Hidden World",
+        "overview": "As Hiccup fulfills his dream of creating a peaceful dragon utopia, Toothless’ discovery of an untamed, elusive mate draws the Night Fury away. When danger mounts at home and Hiccup’s reign as village chief is tested, both dragon and rider must make impossible decisions to save their kind.",
+        "poster_path": "/xvx4Yhf0DVH8G4LzNISpMfFBDy2.jpg",
+        "media_type": "movie",
+        "original_language": "en",
+        "genre_ids": [
+          16,
+          10751,
+          12
+        ],
+        "popularity": 11.2608,
+        "release_date": "2019-01-03",
+        "video": false,
+        "vote_average": 7.749,
+        "vote_count": 7020
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/TXSxV23MWYkezZ3219gtgcSX6n.jpg",
+        "id": 123,
+        "title": "The Lord of the Rings",
+        "original_title": "The Lord of the Rings",
+        "overview": "Young Hobbit Frodo Baggins is thrown into an amazing adventure when he's tasked with destroying the One Ring, created by the dark lord Sauron. Frodo must travel in a small fellowship of nine warriors and accomplices. But it won't be an easy journey for the Fellowship of the Ring, on the ultimate quest to rid Middle-earth of evil.",
+        "poster_path": "/liW0mjvTyLs7UCumaHhx3PpU4VT.jpg",
+        "media_type": "movie",
+        "original_language": "en",
+        "genre_ids": [
+          12,
+          16,
+          14
+        ],
+        "popularity": 5.2553,
+        "release_date": "1978-11-15",
+        "video": false,
+        "vote_average": 6.595,
+        "vote_count": 1030
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/59vDC1BuEQvti24OMr0ZvtAK6R1.jpg",
+        "id": 10191,
+        "title": "How to Train Your Dragon",
+        "original_title": "How to Train Your Dragon",
+        "overview": "As the son of a Viking leader on the cusp of manhood, shy Hiccup Horrendous Haddock III faces a rite of passage: he must kill a dragon to prove his warrior mettle. But after downing a feared dragon, he realizes that he no longer wants to destroy it, and instead befriends the beast – which he names Toothless – much to the chagrin of his warrior father.",
+        "poster_path": "/ygGmAO60t8GyqUo9xYeYxSZAR3b.jpg",
+        "media_type": "movie",
+        "original_language": "en",
+        "genre_ids": [
+          14,
+          12,
+          16,
+          10751
+        ],
+        "popularity": 13.3282,
+        "release_date": "2010-03-18",
+        "video": false,
+        "vote_average": 7.856,
+        "vote_count": 14213
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/yMatVGaUxw3Vi3Z0RsLetvcSYko.jpg",
+        "id": 896536,
+        "title": "The Legend of Ochi",
+        "original_title": "The Legend of Ochi",
+        "overview": "In a remote village on the island of Carpathia, a shy farm girl named Yuri is raised to fear an elusive animal species known as ochi. But when Yuri discovers a wounded baby ochi has been left behind, she escapes on a quest to bring him home.",
+        "poster_path": "/qYyEelO4JfOwE0Ui5KsrCE0O8UA.jpg",
+        "media_type": "movie",
+        "original_language": "en",
+        "genre_ids": [
+          10751,
+          14,
+          12
+        ],
+        "popularity": 7.6693,
+        "release_date": "2025-04-18",
+        "video": false,
+        "vote_average": 6.083,
+        "vote_count": 276
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/bNiiUCQUD7ij5Ybh2GoWSZwqAb1.jpg",
+        "id": 102651,
+        "title": "Maleficent",
+        "original_title": "Maleficent",
+        "overview": "A beautiful, pure-hearted young woman, Maleficent has an idyllic life growing up in a peaceable forest kingdom, until one day when an invading army threatens the harmony of the land. She rises to be the land's fiercest protector, but she ultimately suffers a ruthless betrayal – an act that begins to turn her heart into stone. Bent on revenge, Maleficent faces an epic battle with the invading King's successor and, as a result, places a curse upon his newborn infant Aurora. As the child grows, Maleficent realizes that Aurora holds the key to peace in the kingdom – and to Maleficent's true happiness as well.",
+        "poster_path": "/bDG3yei6AJlEAK3A5wN7RwFXQ7V.jpg",
+        "media_type": "movie",
+        "original_language": "en",
+        "genre_ids": [
+          14,
+          12,
+          28,
+          10751,
+          10749
+        ],
+        "popularity": 13.003,
+        "release_date": "2014-05-28",
+        "video": false,
+        "vote_average": 7.086,
+        "vote_count": 13631
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/l2ji4YiNSPBV69WjGBgU0gCvRqy.jpg",
+        "id": 426543,
+        "title": "The Nutcracker and the Four Realms",
+        "original_title": "The Nutcracker and the Four Realms",
+        "overview": "When Clara’s mother leaves her a mysterious gift, she embarks on a journey to four secret realms—where she discovers her greatest strength could change the world.",
+        "poster_path": "/9vPDY8e7YxLwgVum7YZIUJbr4qc.jpg",
+        "media_type": "movie",
+        "original_language": "en",
+        "genre_ids": [
+          14,
+          12,
+          10751
+        ],
+        "popularity": 5.8961,
+        "release_date": "2018-10-26",
+        "video": false,
+        "vote_average": 6.082,
+        "vote_count": 2233
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/83QeqJ5QPljmAxPdgLv6BMzgo3u.jpg",
+        "id": 451644,
+        "title": "Dragonheart: Battle for the Heartfire",
+        "original_title": "Dragonheart: Battle for the Heartfire",
+        "overview": "When the King Gareth dies, his potential heirs, twin grandchildren who possess the dragon’s unique strengths, use their inherited powers against each other to vie for the throne. When Drago’s source of power – known as the Heartfire – is stolen, more than the throne is at stake; the siblings must end their rivalry with swords and sorcery or the kingdom may fall.",
+        "poster_path": "/21awrY48uEiDOyLYALcuMgE5G7W.jpg",
+        "media_type": "movie",
+        "original_language": "en",
+        "genre_ids": [
+          14,
+          12
+        ],
+        "popularity": 1.4991,
+        "release_date": "2017-07-09",
+        "video": false,
+        "vote_average": 6,
+        "vote_count": 242
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/e0MwhnT6ydLrgQbq4IIABhJdsmo.jpg",
+        "id": 16523,
+        "title": "Where the Wild Things Are",
+        "original_title": "Where the Wild Things Are",
+        "overview": "Max imagines running away from his mom and sailing to a far-off land where large talking beasts—Ira, Carol, Douglas, the Bull, Judith and Alexander—crown him as their king, play rumpus, build forts and discover secret hideaways.",
+        "poster_path": "/sDFV9VEjwTUWF1s5sjOllsb70jk.jpg",
+        "media_type": "movie",
+        "original_language": "en",
+        "genre_ids": [
+          14,
+          18,
+          12,
+          10751
+        ],
+        "popularity": 4.6014,
+        "release_date": "2009-10-16",
+        "video": false,
+        "vote_average": 6.496,
+        "vote_count": 1996
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/r4Q7GKzTiAzr1MGU1b13s9L12YZ.jpg",
+        "id": 14442,
+        "title": "Ella Enchanted",
+        "original_title": "Ella Enchanted",
+        "overview": "Ella lives in a magical world in which each child, at the moment of their birth, is given a virtuous \"gift\" from a fairy godmother. Ella's so-called gift, however, is obedience. This birthright proves itself to be quite the curse once Ella finds herself in the hands of several unscrupulous characters whom she quite literally cannot disobey. Determined to gain control of her life and decisions, Ella sets off on a journey to find her fairy godmother who she hopes will lift the curse. The path, however, isn't easy -- Ella must outwit a slew of unpleasant obstacles including ogres, giants, wicked stepsisters, elves and Prince Charmont's evil uncle, who wants to take over the crown and rule the kingdom.",
+        "poster_path": "/7AyNzwSEpJEG1gBdgwRfXi1cjs8.jpg",
+        "media_type": "movie",
+        "original_language": "en",
+        "genre_ids": [
+          10751,
+          14,
+          35
+        ],
+        "popularity": 4.5255,
+        "release_date": "2004-04-09",
+        "video": false,
+        "vote_average": 6.5,
+        "vote_count": 1949
+      }
+    ],
+    "total_pages": 29,
+    "total_results": 571
+  },
+  "alternative_titles": {
+    "titles": [
+      {
+        "iso_3166_1": "US",
+        "title": "The Chronicles of Narnia - The Voyage of the Dawn Treader - 3D",
+        "type": "3D version"
+      },
+      {
+        "iso_3166_1": "BE",
+        "title": "De kronieken van Narnia : De reis van het drakenschip",
+        "type": "Vlaams"
+      },
+      {
+        "iso_3166_1": "SE",
+        "title": "Berättelsen om Narnia: Kung Caspian och skeppet Gryningen",
+        "type": "alternative title"
+      },
+      {
+        "iso_3166_1": "US",
+        "title": "The Voyage of the Dawn Treader",
+        "type": "working title"
+      },
+      {
+        "iso_3166_1": "US",
+        "title": "The Chronicles of Narnia 3",
+        "type": "working title"
+      },
+      {
+        "iso_3166_1": "GB",
+        "title": "The Voyage of the Dawn Treader",
+        "type": "short title"
+      },
+      {
+        "iso_3166_1": "CO",
+        "title": "Las Crónicas de Narnia: La Travesia del Viajero del Alba",
+        "type": ""
+      },
+      {
+        "iso_3166_1": "BR",
+        "title": "As Crônicas de Nárnia: A Viagem do Peregrino da Alvorada",
+        "type": ""
+      },
+      {
+        "iso_3166_1": "AT",
+        "title": "Die Chroniken von Narnia - Die Reise auf der Morgenröte",
+        "type": ""
+      },
+      {
+        "iso_3166_1": "NL",
+        "title": "De Kronieken van Narnia: De Reis van het Drakenschip",
+        "type": ""
+      },
+      {
+        "iso_3166_1": "PL",
+        "title": "Opowieści z Narnii: Podróż Wędrowca do Świtu",
+        "type": ""
+      },
+      {
+        "iso_3166_1": "DE",
+        "title": "Die Chroniken von Narnia - Die Reise auf der Morgenröte",
+        "type": ""
+      },
+      {
+        "iso_3166_1": "FR",
+        "title": "Le Monde de Narnia, chapitre 3 : L'Odyssée du Passeur d'Aurore",
+        "type": ""
+      },
+      {
+        "iso_3166_1": "US",
+        "title": "The Chronicles of Narnia 3 - The Voyage of the Dawn Treader",
+        "type": ""
+      },
+      {
+        "iso_3166_1": "US",
+        "title": "The Chronicles of Narnia III: The Voyage of the Dawn Treader",
+        "type": "alternative title"
+      },
+      {
+        "iso_3166_1": "DE",
+        "title": "Die Chroniken von Narnia 3: Die Reise auf der Morgenröte",
+        "type": ""
+      },
+      {
+        "iso_3166_1": "VN",
+        "title": "Biên Niên Sử Narnia 3: Hành Trình Trên Tàu Dawn Treader",
+        "type": ""
+      },
+      {
+        "iso_3166_1": "RU",
+        "title": "Покоритель Зари",
+        "type": ""
+      },
+      {
+        "iso_3166_1": "RU",
+        "title": "Хроники Нарнии 3",
+        "type": ""
+      }
+    ]
   }
 }

--- a/tmdb-api/src/jvmTest/resources/tmdb3/tv/tv_details_96677.json
+++ b/tmdb-api/src/jvmTest/resources/tmdb3/tv/tv_details_96677.json
@@ -3005,5 +3005,576 @@
         }
       }
     ]
+  },
+  "keywords": {
+    "results": [
+      {
+        "name": "paris, france",
+        "id": 90
+      },
+      {
+        "name": "based on novel or book",
+        "id": 818
+      },
+      {
+        "name": "investigation",
+        "id": 5340
+      },
+      {
+        "name": "police",
+        "id": 6149
+      },
+      {
+        "name": "thief",
+        "id": 9727
+      },
+      {
+        "name": "revenge",
+        "id": 9748
+      },
+      {
+        "name": "heist",
+        "id": 10051
+      },
+      {
+        "name": "criminal",
+        "id": 15009
+      },
+      {
+        "name": "disguise",
+        "id": 18118
+      },
+      {
+        "name": "dramedy",
+        "id": 203322
+      },
+      {
+        "name": "arsene lupin",
+        "id": 289360
+      },
+      {
+        "name": "thriller",
+        "id": 316362
+      },
+      {
+        "name": "exciting",
+        "id": 319837
+      },
+      {
+        "name": "action",
+        "id": 322496
+      }
+    ]
+  },
+  "recommendations": {
+    "page": 1,
+    "results": [
+      {
+        "adult": false,
+        "backdrop_path": "/rwxxDbG9Kijki7CkmB4k64MSbte.jpg",
+        "id": 790,
+        "name": "Agatha Christie's Poirot",
+        "original_name": "Agatha Christie's Poirot",
+        "overview": "From England to Egypt, accompanied by his elegant and trustworthy sidekicks, the intelligent yet eccentrically-refined Belgian detective Hercule Poirot pits his wits against a collection of first class deceptions.",
+        "poster_path": "/6f4IVfbn8knb7RjdZlGLuW5guDc.jpg",
+        "media_type": "tv",
+        "original_language": "en",
+        "genre_ids": [
+          80,
+          18,
+          9648
+        ],
+        "popularity": 102.5228,
+        "first_air_date": "1989-01-08",
+        "vote_average": 8.2,
+        "vote_count": 535,
+        "origin_country": [
+          "GB"
+        ]
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/cQNhn9WK7jtNWqPVdCP5StLzkyY.jpg",
+        "id": 197242,
+        "name": "Three Pines",
+        "original_name": "Three Pines",
+        "overview": "Chief Inspector Armand Gamache and his team investigate a series of perplexing murders, in the seemingly idyllic village of Three Pines and uncover the buried secrets of its eccentric residents. In the process, Gamache is forced to confront buried secrets of his own. Based on the novels by Louise Penny.",
+        "poster_path": "/r5lbLfjfFZYhr2TfuvKpf7b0HpQ.jpg",
+        "media_type": "tv",
+        "original_language": "en",
+        "genre_ids": [
+          80,
+          18,
+          9648
+        ],
+        "popularity": 8.4465,
+        "first_air_date": "2022-12-01",
+        "vote_average": 6.439,
+        "vote_count": 82,
+        "origin_country": [
+          "CA"
+        ]
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/tSFndbpoEctuYviiSRJHjyC31V9.jpg",
+        "id": 254071,
+        "name": "Steal",
+        "original_name": "Steal",
+        "overview": "A typical day at Lochmill Capital is upended when armed thieves burst in and force Zara and her best friend Luke to execute their demands. In the aftermath, conflicted detective Rhys races against time to find out who stole £4 billion pounds of people's pensions and why.",
+        "poster_path": "/6KmlaPhsohh3Ki9XJUq0jiUYbf3.jpg",
+        "media_type": "tv",
+        "original_language": "en",
+        "genre_ids": [
+          18,
+          80,
+          9648
+        ],
+        "popularity": 15.4609,
+        "first_air_date": "2026-01-21",
+        "vote_average": 7.417,
+        "vote_count": 114,
+        "origin_country": [
+          "GB"
+        ]
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/eKwFd5jJfBZ0el9kpLp0VVvCfy6.jpg",
+        "id": 209479,
+        "name": "Monsieur Spade",
+        "original_name": "Monsieur Spade",
+        "overview": "Detective Sam Spade is pulled out of his tranquil retirement in France to investigate a series of brutal murders.",
+        "poster_path": "/5B0fvoxRPT7mhZMgMSAM27j6QZb.jpg",
+        "media_type": "tv",
+        "original_language": "en",
+        "genre_ids": [
+          18,
+          9648,
+          80
+        ],
+        "popularity": 10.9145,
+        "first_air_date": "2024-01-14",
+        "vote_average": 6.2,
+        "vote_count": 62,
+        "origin_country": [
+          "US"
+        ]
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/1RejXo8s6ot7ZbrgR8J16DVaaTi.jpg",
+        "id": 108181,
+        "name": "Imperfect Women",
+        "original_name": "Imperfect Women",
+        "overview": "After a murder shatters the lives of three best friends, their decades-long bond is tested when an investigation reveals betrayals and shocking truths.",
+        "poster_path": "/wW7rimhnokiQ8V6ha6VKIwHg8IV.jpg",
+        "media_type": "tv",
+        "original_language": "en",
+        "genre_ids": [
+          18,
+          9648,
+          80
+        ],
+        "popularity": 17.748,
+        "first_air_date": "2026-03-17",
+        "vote_average": 5.8,
+        "vote_count": 25,
+        "origin_country": [
+          "US"
+        ]
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/x9yqsGeZjqmlCh5qVfhmFPp2kcH.jpg",
+        "id": 72748,
+        "name": "Strike",
+        "original_name": "Strike",
+        "overview": "A war veteran turned private detective operates out of a tiny office in London’s Denmark Street. Although wounded both physically and psychologically, his unique insight and background as a military police investigator prove crucial in solving complex crimes that have baffled the police. Based on the bestselling novels written by J.K. Rowling under the pseudonym Robert Galbraith.",
+        "poster_path": "/oPTJfwuMLz6Lr3suGK4584MAJAC.jpg",
+        "media_type": "tv",
+        "original_language": "en",
+        "genre_ids": [
+          80,
+          18,
+          9648
+        ],
+        "popularity": 18.7123,
+        "first_air_date": "2017-08-27",
+        "vote_average": 7.2,
+        "vote_count": 239,
+        "origin_country": [
+          "GB"
+        ]
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/2vAOdruqvx9GojXxKi3xVsZZvKU.jpg",
+        "id": 61859,
+        "name": "The Night Manager",
+        "original_name": "The Night Manager",
+        "overview": "Former British soldier Jonathan Pine navigates the shadowy recesses of Whitehall and Washington where an unholy alliance operates between the intelligence community and the secret arms trade. To infiltrate the inner circle of lethal arms dealer Richard Onslow Roper, Pine must himself become a criminal.",
+        "poster_path": "/1MccRnw41qQjREuZkovqP2UX1i3.jpg",
+        "media_type": "tv",
+        "original_language": "en",
+        "genre_ids": [
+          18,
+          9648,
+          80
+        ],
+        "popularity": 25.4425,
+        "first_air_date": "2016-02-21",
+        "vote_average": 7.7,
+        "vote_count": 1258,
+        "origin_country": [
+          "GB"
+        ]
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/eAo5vQ5dxRaL6G8NFOGyuZCYCcL.jpg",
+        "id": 64581,
+        "name": "Maigret",
+        "original_name": "Maigret",
+        "overview": "The pragmatic, reserved and refined Maigret investigates murders in his singular unhurried manner and inevitably discovers the truth.",
+        "poster_path": "/kQQARcBsgzd5d2s7ZPA5NjHF33S.jpg",
+        "media_type": "tv",
+        "original_language": "fr",
+        "genre_ids": [
+          80,
+          9648,
+          18
+        ],
+        "popularity": 20.6514,
+        "first_air_date": "1991-12-01",
+        "vote_average": 7.6,
+        "vote_count": 22,
+        "origin_country": [
+          "BE",
+          "FR"
+        ]
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/3gRDZotvt7FqNyTU4bU9S2OCEPi.jpg",
+        "id": 66599,
+        "name": "Private Eyes",
+        "original_name": "Private Eyes",
+        "overview": "Ex-pro hockey player Matt Shade irrevocably changes his life when he teams up with fierce P.I. Angie Everett to form an unlikely investigative powerhouse.",
+        "poster_path": "/yPt9IuY2D8g6Lpwh8O8wCDixzt9.jpg",
+        "media_type": "tv",
+        "original_language": "en",
+        "genre_ids": [
+          80,
+          18,
+          35
+        ],
+        "popularity": 27.0934,
+        "first_air_date": "2016-05-26",
+        "vote_average": 7.3,
+        "vote_count": 143,
+        "origin_country": [
+          "CA"
+        ]
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/1lBEfsnzUkxtxzvFwimENpM6bEP.jpg",
+        "id": 6127,
+        "name": "Agatha Christie's Marple",
+        "original_name": "Agatha Christie's Marple",
+        "overview": "The adventures of Miss Jane Marple, an elderly spinster living in the quiet little village of St Mary Mead. During her many visits to friends and relatives in other villages, Miss Marple often stumbles upon mysterious murders which she helps solve. Although the police are sometimes reluctant to accept Miss Marple's help, her reputation and unparalleled powers of observation eventually win them over.",
+        "poster_path": "/nVswrZQpqQND9TgwgbWgz18KgAo.jpg",
+        "media_type": "tv",
+        "original_language": "en",
+        "genre_ids": [
+          18,
+          80,
+          9648
+        ],
+        "popularity": 48.0841,
+        "first_air_date": "2004-12-12",
+        "vote_average": 7.8,
+        "vote_count": 138,
+        "origin_country": [
+          "GB"
+        ]
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/wofevfOdZrHPqFnhZTkHHV25IOO.jpg",
+        "id": 587,
+        "name": "Barnaby Jones",
+        "original_name": "Barnaby Jones",
+        "overview": "Barnaby Jones is a television detective series starring Buddy Ebsen and Lee Meriwether as father- and daughter-in-law who run a private detective firm in Los Angeles. The show ran on CBS from January 28, 1973 to April 3, 1980, beginning as a midseason replacement. William Conrad guest starred as Frank Cannon of Cannon on the first episode of Barnaby Jones, \"Requiem for a Son\" and the two series had a two-part crossover episode in 1975, \"The Deadly Conspiracy\".",
+        "poster_path": "/wn1kkCGHJcUQ7C8umfQH9LL2zXR.jpg",
+        "media_type": "tv",
+        "original_language": "en",
+        "genre_ids": [
+          80,
+          18,
+          9648
+        ],
+        "popularity": 21.9514,
+        "first_air_date": "1973-01-28",
+        "vote_average": 6.9,
+        "vote_count": 28,
+        "origin_country": [
+          "US"
+        ]
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/AdfZ3W15jYvZLwVUcVGqOd1g0CE.jpg",
+        "id": 137127,
+        "name": "Dalgliesh",
+        "original_name": "Dalgliesh",
+        "overview": "A recent widower and acclaimed poet, enigmatic Inspector Adam Dalgliesh employs his exceptional empathy and insight to plumb the darker depths of the human psyche while investigating complex crimes in 1970s England.",
+        "poster_path": "/8pqCanIwJFehhZdP00gXE0qc9xc.jpg",
+        "media_type": "tv",
+        "original_language": "en",
+        "genre_ids": [
+          80,
+          18,
+          9648
+        ],
+        "popularity": 13.1776,
+        "first_air_date": "2021-11-04",
+        "vote_average": 6.683,
+        "vote_count": 60,
+        "origin_country": [
+          "GB"
+        ]
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/wixjwQv8aPfIwbc7euj0fPPsMjT.jpg",
+        "id": 3216,
+        "name": "Baretta",
+        "original_name": "Baretta",
+        "overview": "Baretta is an American detective television series which ran on ABC from 1975 to 1978. The show was a milder version of a successful 1973–74 ABC series, Toma, starring Tony Musante as chameleon-like, real-life New Jersey police officer David Toma. While popular, Toma received intense criticism at the time for its realistic and frequent depiction of police and criminal violence. When Musante left the series after a single season, the concept was retooled as Baretta, with Robert Blake in the title role.",
+        "poster_path": "/xayGSRT2GbcFTwNIqt6l355v29F.jpg",
+        "media_type": "tv",
+        "original_language": "en",
+        "genre_ids": [
+          80,
+          18,
+          9648
+        ],
+        "popularity": 20.1378,
+        "first_air_date": "1975-01-17",
+        "vote_average": 6.4,
+        "vote_count": 38,
+        "origin_country": [
+          "US"
+        ]
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/w4HqCpNojW3kbgtj4qHCnf5G7bf.jpg",
+        "id": 213306,
+        "name": "Cross",
+        "original_name": "Cross",
+        "overview": "Alex Cross is a brilliant but flawed homicide detective and full of contradictions. A doting father and family man, Cross is single-minded to the point of obsession when he hunts killers. He is desperate for love, but his wife’s murder has left him too damaged to receive it.",
+        "poster_path": "/6hhKdavCEZi8d584ZtIrQIrBvZI.jpg",
+        "media_type": "tv",
+        "original_language": "en",
+        "genre_ids": [
+          80,
+          18,
+          9648
+        ],
+        "popularity": 27.6277,
+        "first_air_date": "2024-11-14",
+        "vote_average": 7.019,
+        "vote_count": 268,
+        "origin_country": [
+          "US"
+        ]
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/aP0V3qTB1iy3JW90EKVpLPNhMia.jpg",
+        "id": 122194,
+        "name": "CSI: Vegas",
+        "original_name": "CSI: Vegas",
+        "overview": "Facing an existential threat that could bring down the Crime Lab, a brilliant team of forensic investigators must welcome back old friends and deploy new techniques to preserve and serve justice in Sin City.",
+        "poster_path": "/8DtOnaOQPiptM9umpV0Xntwv9t3.jpg",
+        "media_type": "tv",
+        "original_language": "en",
+        "genre_ids": [
+          80,
+          18,
+          9648
+        ],
+        "popularity": 24.9682,
+        "first_air_date": "2021-10-06",
+        "vote_average": 7.8,
+        "vote_count": 305,
+        "origin_country": [
+          "US"
+        ]
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/9PARvL1FQtyjNhLF6AT6Oanqg1U.jpg",
+        "id": 80213,
+        "name": "The Purge",
+        "original_name": "The Purge",
+        "overview": "Set in a dystopian America ruled by a totalitarian political party, the series follows several seemingly unrelated characters living in a small city. Tying them all together is a mysterious savior who’s impeccably equipped for everything the night throws at them. As the clock winds down with their fates hanging in the balance, each character is forced to reckon with their pasts as they discover how far they will go to survive the night.",
+        "poster_path": "/9CaS2XFd0Db42grzzVBnWcSkrbg.jpg",
+        "media_type": "tv",
+        "original_language": "en",
+        "genre_ids": [
+          9648,
+          80,
+          18
+        ],
+        "popularity": 21.0011,
+        "first_air_date": "2018-09-04",
+        "vote_average": 6.9,
+        "vote_count": 3381,
+        "origin_country": [
+          "US"
+        ]
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/quVbFfkM3vV6FrbS7INnqNL9hRy.jpg",
+        "id": 130273,
+        "name": "Annika",
+        "original_name": "Annika",
+        "overview": "The sharp, witty and enigmatic DI Annika Strandhed, as she heads up a new specialist Marine Homicide Unit (MHU) that is tasked with investigating the unexplained, brutal, and seemingly unfathomable murders.",
+        "poster_path": "/8jRoGLyOnTMyLhWajG0ye6KKw0h.jpg",
+        "media_type": "tv",
+        "original_language": "en",
+        "genre_ids": [
+          9648,
+          80,
+          18
+        ],
+        "popularity": 9.0375,
+        "first_air_date": "2021-08-17",
+        "vote_average": 7.137,
+        "vote_count": 62,
+        "origin_country": [
+          "GB"
+        ]
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/gQr75UrfUsu799Xwzic1TYtZGTD.jpg",
+        "id": 11726,
+        "name": "Spiral",
+        "original_name": "Engrenages",
+        "overview": "This gritty crime drama set in the dark underbelly of Paris follows police officers and lawyers as they investigate and prosecute crimes. Throw any romantic notion of Paris out the window. Crime is dark. The legal system is darker. This is Spiral.",
+        "poster_path": "/t4i4wJCRUDkblYaqp3ln4vENQdC.jpg",
+        "media_type": "tv",
+        "original_language": "fr",
+        "genre_ids": [
+          10759,
+          80,
+          18,
+          9648
+        ],
+        "popularity": 10.7945,
+        "first_air_date": "2005-12-13",
+        "vote_average": 7.9,
+        "vote_count": 91,
+        "origin_country": [
+          "FR"
+        ]
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/rp0f5vHNiAbe5EEIaw7XhJHQ7og.jpg",
+        "id": 218351,
+        "name": "The Gold",
+        "original_name": "The Gold",
+        "overview": "On 26 November 1983, six armed men break into the Brink's-Mat security depot, stumbling across gold bullion worth £26m.",
+        "poster_path": "/9JY9Gza4HQhXjIPXg9uSy8FeiSM.jpg",
+        "media_type": "tv",
+        "original_language": "en",
+        "genre_ids": [
+          80,
+          18
+        ],
+        "popularity": 16.2836,
+        "first_air_date": "2023-02-12",
+        "vote_average": 7.3,
+        "vote_count": 66,
+        "origin_country": [
+          "GB"
+        ]
+      },
+      {
+        "adult": false,
+        "backdrop_path": "/bWTk5MoSYmtr34EQWXsEAFBeNiS.jpg",
+        "id": 1167,
+        "name": "The Inspector Lynley Mysteries",
+        "original_name": "The Inspector Lynley Mysteries",
+        "overview": "DS Barbara Havers is assigned to work with the upper-crust DI Thomas Lynley to solve murders.",
+        "poster_path": "/d68bISjO6e6cOtgeygJO471FUIh.jpg",
+        "media_type": "tv",
+        "original_language": "en",
+        "genre_ids": [
+          80,
+          18
+        ],
+        "popularity": 15.3796,
+        "first_air_date": "2002-04-08",
+        "vote_average": 7.2,
+        "vote_count": 40,
+        "origin_country": [
+          "GB"
+        ]
+      }
+    ],
+    "total_pages": 42,
+    "total_results": 821
+  },
+  "alternative_titles": {
+    "results": [
+      {
+        "iso_3166_1": "CN",
+        "title": "绅士怪盗",
+        "type": ""
+      },
+      {
+        "iso_3166_1": "CN",
+        "title": "亚森·罗苹",
+        "type": ""
+      },
+      {
+        "iso_3166_1": "CN",
+        "title": "怪盗罗苹",
+        "type": ""
+      },
+      {
+        "iso_3166_1": "CN",
+        "title": "亚森·罗宾",
+        "type": ""
+      },
+      {
+        "iso_3166_1": "FR",
+        "title": "Arsène Lupin",
+        "type": "working title"
+      },
+      {
+        "iso_3166_1": "FR",
+        "title": "Lupin : dans l'ombre d'Arsène",
+        "type": "part 1"
+      },
+      {
+        "iso_3166_1": "IR",
+        "title": "لوپن",
+        "type": ""
+      },
+      {
+        "iso_3166_1": "UA",
+        "title": "Арсен Люпен",
+        "type": ""
+      }
+    ]
   }
 }


### PR DESCRIPTION
All three of these are supported by the movie and series details endpoints.

- Updates the test fixtures to include the latest data for the new appended fields.
- Update editor config to match current json formatting